### PR TITLE
Make HPR meta again.

### DIFF
--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -65,11 +65,11 @@
 
 /datum/component/bonus_damage_stack/proc/stat_append(mob/M, list/L)
 	SIGNAL_HANDLER
-	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.2]%"
+	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.1]%"
 
-/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
+/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 10% damage bonus at most
 	SIGNAL_HANDLER
-	damage_data["bonus_damage"] = damage_data["damage"] * (min(bonus_damage_stacks, bonus_damage_cap) / 1000)
+	damage_data["bonus_damage"] = damage_data["damage"] * (2 *(min(bonus_damage_stacks, bonus_damage_cap) / 1000))
 
 #undef COLOR_BONUS_DAMAGE
 #undef BONUS_DAMAGE_MAX_ALPHA

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -67,7 +67,7 @@
 	SIGNAL_HANDLER
 	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.1]%"
 
-/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 30% damage bonus at most
+/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
 	SIGNAL_HANDLER
 	damage_data["bonus_damage"] = damage_data["damage"] *(min(bonus_damage_stacks, bonus_damage_cap) / 1000)
 

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -12,7 +12,7 @@
 	/// extra damage multiplier, divided by 1000
 	var/bonus_damage_stacks = 0
 	/// extra damage multiplier, divided by 1000
-	var/bonus_damage_cap = 200
+	var/bonus_damage_cap = 250
 	/// Last world.time that the afflicted was hit by a holo-targeting round.
 	var/last_stack
 
@@ -67,7 +67,7 @@
 	SIGNAL_HANDLER
 	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.2]%"
 
-/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
+/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 25% damage bonus at most
 	SIGNAL_HANDLER
 	damage_data["bonus_damage"] = damage_data["damage"] * (min(bonus_damage_stacks, bonus_damage_cap) / 1000)
 

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -65,9 +65,9 @@
 
 /datum/component/bonus_damage_stack/proc/stat_append(mob/M, list/L)
 	SIGNAL_HANDLER
-	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.1]%"
+	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.2]%"
 
-/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 10% damage bonus at most
+/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
 	SIGNAL_HANDLER
 	damage_data["bonus_damage"] = damage_data["damage"] * (min(bonus_damage_stacks, bonus_damage_cap) / 1000)
 

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -12,7 +12,7 @@
 	/// extra damage multiplier, divided by 1000
 	var/bonus_damage_stacks = 0
 	/// extra damage multiplier, divided by 1000
-	var/bonus_damage_cap = 100
+	var/bonus_damage_cap = 300
 	/// Last world.time that the afflicted was hit by a holo-targeting round.
 	var/last_stack
 
@@ -67,9 +67,9 @@
 	SIGNAL_HANDLER
 	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.1]%"
 
-/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 10% damage bonus at most
+/datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 30% damage bonus at most
 	SIGNAL_HANDLER
-	damage_data["bonus_damage"] = damage_data["damage"] * (2 *(min(bonus_damage_stacks, bonus_damage_cap) / 1000))
+	damage_data["bonus_damage"] = damage_data["damage"] *(min(bonus_damage_stacks, bonus_damage_cap) / 1000)
 
 #undef COLOR_BONUS_DAMAGE
 #undef BONUS_DAMAGE_MAX_ALPHA

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -12,7 +12,7 @@
 	/// extra damage multiplier, divided by 1000
 	var/bonus_damage_stacks = 0
 	/// extra damage multiplier, divided by 1000
-	var/bonus_damage_cap = 300
+	var/bonus_damage_cap = 200
 	/// Last world.time that the afflicted was hit by a holo-targeting round.
 	var/last_stack
 

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -69,7 +69,7 @@
 
 /datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
 	SIGNAL_HANDLER
-	damage_data["bonus_damage"] = damage_data["damage"] *(min(bonus_damage_stacks, bonus_damage_cap) / 1000)
+	damage_data["bonus_damage"] = damage_data["damage"] * (min(bonus_damage_stacks, bonus_damage_cap) / 1000)
 
 #undef COLOR_BONUS_DAMAGE
 #undef BONUS_DAMAGE_MAX_ALPHA

--- a/code/datums/components/bonus_damage_stack.dm
+++ b/code/datums/components/bonus_damage_stack.dm
@@ -65,7 +65,7 @@
 
 /datum/component/bonus_damage_stack/proc/stat_append(mob/M, list/L)
 	SIGNAL_HANDLER
-	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.1]%"
+	L += "Bonus Damage Taken: [bonus_damage_stacks * 0.2]%"
 
 /datum/component/bonus_damage_stack/proc/get_bonus_damage(mob/M, list/damage_data) // 20% damage bonus at most
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -901,8 +901,8 @@
 
 /datum/ammo/bullet/rifle/holo_target
 	name = "holo-targeting rifle bullet"
-	damage = 30
-	var/holo_stacks = 10
+	damage = 27
+	var/holo_stacks = 15
 
 /datum/ammo/bullet/rifle/holo_target/on_hit_mob(mob/M, obj/projectile/P)
 	. = ..()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -901,8 +901,8 @@
 
 /datum/ammo/bullet/rifle/holo_target
 	name = "holo-targeting rifle bullet"
-	damage = 27
-	var/holo_stacks = 15
+	damage = 30
+	var/holo_stacks = 20
 
 /datum/ammo/bullet/rifle/holo_target/on_hit_mob(mob/M, obj/projectile/P)
 	. = ..()


### PR DESCRIPTION
Делаю ХПР чуть более хорошим в бою. Делаем из неё саппорт-винтовку на передовой
Количество урона за стак повышен вдвое. Окончательное увеличение урона от других источников не 10% а 20%.
В сравнении с МК1, голотаргеты убивают цель за 8-9 секунд. МК1 убивает за 5-8 секунд. Замеры были на стандартном равагере.
:cl:
balance: повышение урона повышенно, количество стаков повышено
/:cl: