### PR TITLE
ERT Патч

### DIFF
--- a/code/datums/emergency_calls/big_game_hunter.dm
+++ b/code/datums/emergency_calls/big_game_hunter.dm
@@ -4,7 +4,7 @@
 	name = "Fun - Big Game Hunter (solo)"
 	mob_max = 1
 	mob_min = 1
-	probability = 10
+	probability = 8
 	objectives = "Get some good trophies. The more dangerous, the better!"
 	hostility = TRUE
 

--- a/code/datums/emergency_calls/big_game_hunter.dm
+++ b/code/datums/emergency_calls/big_game_hunter.dm
@@ -4,7 +4,7 @@
 	name = "Fun - Big Game Hunter (solo)"
 	mob_max = 1
 	mob_min = 1
-	probability = 5
+	probability = 10
 	objectives = "Get some good trophies. The more dangerous, the better!"
 	hostility = TRUE
 

--- a/code/datums/emergency_calls/big_game_hunter.dm
+++ b/code/datums/emergency_calls/big_game_hunter.dm
@@ -4,7 +4,7 @@
 	name = "Fun - Big Game Hunter (solo)"
 	mob_max = 1
 	mob_min = 1
-	probability = 0
+	probability = 5
 	objectives = "Get some good trophies. The more dangerous, the better!"
 	hostility = TRUE
 

--- a/code/datums/emergency_calls/contractor.dm
+++ b/code/datums/emergency_calls/contractor.dm
@@ -87,7 +87,7 @@
 /datum/emergency_call/contractors/covert
 	name = "Military Contractors (Covert) (Hostile to WY)"
 	mob_max = 7
-	probability = 0
+	probability = 5
 	max_medics = 1
 	max_engineers = 1
 	max_heavies = 1

--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -8,7 +8,7 @@
 	mob_min = 5
 	arrival_message = "'!`2*%еб#*зите и*h$хm в!сl%х. Н& о*vтаeв(oт^е с&*ви%лей.*v$e %#d на^'"
 	objectives = "Whiteout protocol is in effect for the target. Ensure there are no traces of the infestation or any witnesses."
-	probability = 0
+	probability = 3
 	shuttle_id = "Distress_PMC"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pmc
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_pmc/item

--- a/code/datums/emergency_calls/deus_vult.dm
+++ b/code/datums/emergency_calls/deus_vult.dm
@@ -7,7 +7,7 @@
 	max_heavies = 10
 	arrival_message = "'Deus le volt. Deus le volt! DEUS LE VOLT!!'"
 	objectives = "Clense the place of all that is unholy! Die in glory!"
-	probability = 0
+	probability = 5
 	hostility = TRUE
 
 /datum/emergency_call/deus_vult/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/hefa_knight.dm
+++ b/code/datums/emergency_calls/hefa_knight.dm
@@ -5,7 +5,7 @@
 	mob_min = 3
 	arrival_message = "'Падгатовьтись сдаца HEFAs па приказю!'"
 	objectives = "You are a Brother of the Order of HEFA! You and your fellow brothers must retrieve as many HEFAs as possible!"
-	probability = 0
+	probability = 5
 	hostility = TRUE
 
 /datum/emergency_call/hefa_knight/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/pirates.dm
+++ b/code/datums/emergency_calls/pirates.dm
@@ -6,7 +6,7 @@
 	mob_min = 10
 	arrival_message = "'Чтоо-о-о мы делаем с пьяным моряк-о-о-м? Что делаем с пьяным моряк-о-о-о-м? Что мы делаем с пьяным моряком с утра пораньше?'"
 	objectives = "Pirate! Loot! Ransom!"
-	probability = 0
+	probability = 10
 	hostility = TRUE
 
 /datum/emergency_call/pirates/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/pirates.dm
+++ b/code/datums/emergency_calls/pirates.dm
@@ -6,7 +6,7 @@
 	mob_min = 10
 	arrival_message = "'Чтоо-о-о мы делаем с пьяным моряк-о-о-м? Что делаем с пьяным моряк-о-о-о-м? Что мы делаем с пьяным моряком с утра пораньше?'"
 	objectives = "Pirate! Loot! Ransom!"
-	probability = 10
+	probability = 7
 	hostility = TRUE
 
 /datum/emergency_call/pirates/create_member(datum/mind/M, turf/override_spawn_loc)

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -8,7 +8,7 @@
 	objectives = "Make sure you get a tip!"
 	shuttle_id = "Distress_Small"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza
-	probability = 5
+	probability = 7
 
 /datum/emergency_call/pizza/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -8,7 +8,7 @@
 	objectives = "Make sure you get a tip!"
 	shuttle_id = "Distress_Small"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza
-	probability = 0
+	probability = 10
 
 /datum/emergency_call/pizza/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -8,7 +8,7 @@
 	objectives = "Make sure you get a tip!"
 	shuttle_id = "Distress_Small"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_pizza
-	probability = 10
+	probability = 5
 
 /datum/emergency_call/pizza/create_member(datum/mind/M, turf/override_spawn_loc)
 	var/turf/spawn_loc = override_spawn_loc ? override_spawn_loc : get_spawn_point()

--- a/code/datums/emergency_calls/royal_marines.dm
+++ b/code/datums/emergency_calls/royal_marines.dm
@@ -1,7 +1,7 @@
 /datum/emergency_call/royal_marines
 	name = "Royal Marines Commando (Squad) (Friendly)"
 	mob_max = 7
-	probability = 0
+	probability = 7
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_twe
 	item_spawn = /obj/effect/landmark/ert_spawns/distress_twe/item
 	max_engineers =  0

--- a/code/datums/emergency_calls/souto.dm
+++ b/code/datums/emergency_calls/souto.dm
@@ -5,7 +5,7 @@
 	mob_max = 1
 	mob_min = 1
 	objectives = "Party like it's 1999!"
-	probability = 0
+	probability = 7
 
 /datum/emergency_call/souto/New()
 	arrival_message = "Give a round of applause for the marine who sent in ten-thousand Souto tabs to get me here! [MAIN_SHIP_NAME], Souto Man's here to party with YOU!"

--- a/code/datums/emergency_calls/upp_commando.dm
+++ b/code/datums/emergency_calls/upp_commando.dm
@@ -3,7 +3,7 @@
 /datum/emergency_call/upp_commando
 	name = "UPP Commandos"
 	mob_max = 6
-	probability = 0
+	probability = 5
 	objectives = "Stealthily assault the ship. Use your silenced weapons, tranquilizers, and night vision to get the advantage on the enemy. Take out the power systems, comms and engine. Stick together and keep a low profile."
 	shuttle_id = "Distress_UPP"
 	name_of_spawn = /obj/effect/landmark/ert_spawns/distress_upp

--- a/code/datums/emergency_calls/xeno_cultists.dm
+++ b/code/datums/emergency_calls/xeno_cultists.dm
@@ -4,7 +4,7 @@
 	mob_max = 6
 	arrival_message = "'Ia! Ia!'"
 	objectives = "Support the Xenomorphs in any way, up to and including giving your life for them!"
-	probability = 0
+	probability = 5
 	hostility = TRUE
 	var/max_synths = 1
 	var/synths = 0

--- a/code/datums/emergency_calls/zombie.dm
+++ b/code/datums/emergency_calls/zombie.dm
@@ -3,7 +3,7 @@
 	name = "Zombies"
 	mob_max = 8
 	mob_min = 1
-	probability = 0
+	probability = 3
 	auto_shuttle_launch = TRUE //can't use the shuttle console with zombie claws, so has to autolaunch.
 	hostility = TRUE
 

--- a/code/modules/shuttle/dropship_hijack.dm
+++ b/code/modules/shuttle/dropship_hijack.dm
@@ -164,10 +164,11 @@
 
 	shuttle.crashing = TRUE
 
-	marine_announcement("ДЕСАНТНЫЙ КОРАБЛЬ ПРЯМО ПО КУРСУ. АВАРИЯ НЕИЗБЕЖНА." , "ТРЕВОГА", 'sound/AI/dropship_emergency.ogg', logging = ARES_LOG_SECURITY)
-
 	notify_ghosts(header = "Столкновение с десантным кораблем", message = "Десантный корабль вот-вот упадет на [get_area_name(crash_site)]!", source = crash_site, extra_large = TRUE)
-	final_announcement = TRUE
+	if(!ferry_crashed)
+		marine_announcement("ДЕСАНТНЫЙ КОРАБЛЬ ПРЯМО ПО КУРСУ. АВАРИЯ НЕИЗБЕЖНА." , "ТРЕВОГА", 'sound/AI/dropship_emergency.ogg', logging = ARES_LOG_SECURITY)
+		final_announcement = TRUE
+		ferry_crashed = FALSE
 
 	playsound_area(get_area(crash_site), 'sound/effects/engine_landing.ogg', 100)
 	playsound_area(get_area(crash_site), channel = SOUND_CHANNEL_AMBIENCE, status = SOUND_UPDATE)

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -436,18 +436,17 @@
 
 	in_transit_time_left = 0
 
-	if(Alm.ferry_crashed)
-		Alm.ferry_crashed = FALSE
-		return FALSE
 	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS)
 		return FALSE //If a nuke is in progress, don't attempt a landing.
 
 	//This is where things change and shit gets real
 
-	marine_announcement("ДЕСАНТНЫЙ КОРАБЛЬ ПРЯМО ПО КУРСУ. АВАРИЯ НЕИЗБЕЖНА." , "ТРЕВОГА", 'sound/AI/dropship_emergency.ogg', logging = ARES_LOG_SECURITY)
-
 	for(var/mob/dead/observer/observer as anything in GLOB.observer_list)
 		to_chat(observer, SPAN_DEADSAY(FONT_SIZE_LARGE("The dropship is about to impact [get_area_name(T_trg)]" + " [OBSERVER_JMP(observer, T_trg)]")))
+
+	if(!Alm.ferry_crashed)
+		marine_announcement("ДЕСАНТНЫЙ КОРАБЛЬ ПРЯМО ПО КУРСУ. АВАРИЯ НЕИЗБЕЖНА." , "ТРЕВОГА", 'sound/AI/dropship_emergency.ogg', logging = ARES_LOG_SECURITY)
+		Alm.ferry_crashed = FALSE
 
 	playsound_area(get_area(turfs_int[sound_target]), sound_landing, 100)
 	playsound_area(get_area(turfs_int[sound_target]), channel = SOUND_CHANNEL_AMBIENCE, status = SOUND_UPDATE)


### PR DESCRIPTION
# Что имеется

Многие типы ЕРТ не использовались в игре или были отключены за последние апдейты (н.п. доставка пиццы) - возвращаем их.

Конкретно:
    - Ван Бандольер - шанс 8%
    - Враждебные Contractors - 5%
    - Дедсквад ВЮ - 3%
    - Деус Вульт - 5%
    - HEFA - 5%
    - Пираты - 7%
    - Доставка пиццы - 7%
    - Royal марины - 7%
    - Соуто - 5%
    - UPP Commandos - 5%
    - Ксено культисты - 5%
    - Зомби - 3%


# Чейнжлог

:cl:
add: Добавление старых/новых ЕРТ отрядов в ротацию.
/:cl: