### PR TITLE
Станции для ЕРТ

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -163,6 +163,7 @@
 #define SS_INIT_PLAYTIME   -29
 #define SS_INIT_PREDSHIPS  -30
 #define SS_INIT_OBJECTIVES -31
+#define SS_INIT_ERTSTATIONS  -32
 #define SS_INIT_MINIMAP    -34
 #define SS_INIT_STATPANELS -98
 #define SS_INIT_CHAT    -100 //Should be last to ensure chat remains smooth during init.

--- a/code/controllers/subsystem/ertstations.dm
+++ b/code/controllers/subsystem/ertstations.dm
@@ -1,0 +1,77 @@
+SUBSYSTEM_DEF(ertstations)
+	name   = "ERTStations"
+	init_order = SS_INIT_ERTSTATIONS
+	flags  = SS_NO_FIRE
+
+	var/datum/map_template/ship_templateWY // Current ship template in use
+	var/datum/map_template/ship_templateUPP // Current ship template in use
+	var/datum/map_template/ship_templateTWE // Current ship template in use
+	var/datum/map_template/ship_templateCLF // Current ship template in use
+	var/list/list/managed_z1   // Maps initating clan id to list(datum/space_level, list/turf(spawns))
+	var/list/list/managed_z2   // Maps initating clan id to list(datum/space_level, list/turf(spawns))
+	var/list/list/managed_z3   // Maps initating clan id to list(datum/space_level, list/turf(spawns))
+	var/list/list/managed_z4   // Maps initating clan id to list(datum/space_level, list/turf(spawns))
+	var/list/turf/spawnpoints // List of all spawn landmark locations
+	/* Note we map clan_id as string due to legacy code using them internally */
+
+/datum/controller/subsystem/ertstations/Initialize(timeofday)
+	if(!ship_templateWY)
+		ship_templateWY = new /datum/map_template("maps/templates/upp_ert_station.dmm", cache = TRUE)
+		LAZYINITLIST(managed_z1)
+		load_new(5)
+	if(!ship_templateUPP)
+		ship_templateUPP = new /datum/map_template("maps/templates/weyland_ert_station.dmm", cache = TRUE)
+		LAZYINITLIST(managed_z2)
+		load_new(6)
+	if(!ship_templateTWE)
+		ship_templateTWE = new /datum/map_template("maps/templates/twe_ert_station.dmm", cache = TRUE)
+		LAZYINITLIST(managed_z3)
+		load_new(7)
+	if(!ship_templateCLF)
+		ship_templateCLF = new /datum/map_template("maps/templates/clf_ert_station.dmm", cache = TRUE)
+		LAZYINITLIST(managed_z4)
+		load_new(8)
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/ertstations/proc/load_new(initiating_ert_id)
+	RETURN_TYPE(/list)
+	if(isnum(initiating_ert_id))
+		initiating_ert_id = "[initiating_ert_id]"
+	if(!initiating_ert_id)
+		return NONE
+	if(initiating_ert_id in managed_z1)
+		return managed_z1[initiating_ert_id]
+	if(initiating_ert_id in managed_z2)
+		return managed_z2[initiating_ert_id]
+	if(initiating_ert_id in managed_z3)
+		return managed_z3[initiating_ert_id]
+	if(initiating_ert_id in managed_z4)
+		return managed_z4[initiating_ert_id]
+	if(ship_templateWY)
+		var/datum/space_level/level1 = ship_templateWY.load_new_z()
+		if(level1)
+			var/list/turf/new_spawns = list()
+			if(managed_z1)
+				managed_z1[initiating_ert_id] = list(level1, new_spawns)
+			return managed_z1[initiating_ert_id]
+	if(ship_templateUPP)
+		var/datum/space_level/level2 = ship_templateUPP.load_new_z()
+		if(level2)
+			var/list/turf/new_spawns = list()
+			if(managed_z2)
+				managed_z2[initiating_ert_id] = list(level2, new_spawns)
+			return managed_z2[initiating_ert_id]
+	if(ship_templateTWE)
+		var/datum/space_level/level3 = ship_templateTWE.load_new_z()
+		if(level3)
+			var/list/turf/new_spawns = list()
+			if(managed_z3)
+				managed_z3[initiating_ert_id] = list(level3, new_spawns)
+			return managed_z3[initiating_ert_id]
+	if(ship_templateCLF)
+		var/datum/space_level/level4 = ship_templateCLF.load_new_z()
+		if(level4)
+			var/list/turf/new_spawns = list()
+			if(managed_z4)
+				managed_z4[initiating_ert_id] = list(level4, new_spawns)
+			return managed_z4[initiating_ert_id]

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -236,6 +236,7 @@ s// DM Environment file for colonialmarines.dme.
 #include "code\controllers\subsystem\dcs.dm"
 #include "code\controllers\subsystem\decorator.dm"
 #include "code\controllers\subsystem\disease.dm"
+#include "code\controllers\subsystem\ertstations.dm"
 #include "code\controllers\subsystem\events.dm"
 #include "code\controllers\subsystem\fail_to_topic.dm"
 #include "code\controllers\subsystem\fast_machinery.dm"

--- a/maps/map_files/generic/Admin_level.dmm
+++ b/maps/map_files/generic/Admin_level.dmm
@@ -440,10 +440,6 @@
 	icon_state = "sterile_green_side"
 	},
 /area/adminlevel/ert_station)
-"hP" = (
-/obj/docking_port/stationary/emergency_response/idle_port1,
-/turf/open/floor/plating,
-/area/adminlevel/ert_station)
 "hZ" = (
 /obj/structure/sign/poster/art,
 /turf/closed/wall/r_wall/unmeltable,
@@ -482,14 +478,6 @@
 /obj/effect/landmark/newplayer_start,
 /turf/open/floor,
 /area/start)
-"kn" = (
-/obj/docking_port/stationary/emergency_response/idle_port3,
-/turf/open/floor/plating,
-/area/adminlevel/ert_station)
-"ks" = (
-/obj/docking_port/stationary/emergency_response/idle_port2,
-/turf/open/floor/plating,
-/area/adminlevel/ert_station)
 "kx" = (
 /turf/closed/wall/indestructible/splashscreen,
 /area/start)
@@ -792,10 +780,6 @@
 /turf/open/floor/prison{
 	icon_state = "kitchen"
 	},
-/area/adminlevel/ert_station)
-"ur" = (
-/obj/docking_port/stationary/emergency_response/idle_port6,
-/turf/open/floor/plating,
 /area/adminlevel/ert_station)
 "uI" = (
 /turf/open/floor/almayer{
@@ -3589,7 +3573,7 @@ FB
 FB
 FB
 FB
-hP
+FB
 FB
 Fo
 wW
@@ -3607,7 +3591,7 @@ FB
 FB
 FB
 FB
-ks
+FB
 FB
 Fo
 wW
@@ -7237,7 +7221,7 @@ FB
 FB
 FB
 FB
-ur
+FB
 FB
 Fo
 wW
@@ -7255,7 +7239,7 @@ FB
 FB
 FB
 FB
-kn
+FB
 FB
 Fo
 wW

--- a/maps/templates/clf_ert_station.dmm
+++ b/maps/templates/clf_ert_station.dmm
@@ -23,7 +23,7 @@
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /obj/item/bedsheet/brown{
 	pixel_y = 13
@@ -346,7 +346,7 @@
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /obj/item/bedsheet/brown{
 	pixel_y = 13
@@ -595,7 +595,7 @@
 	icon_state = "abed"
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /turf/open/floor/wood,
 /area/adminlevel/ert_station/clf_station)
@@ -676,7 +676,7 @@
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /obj/item/bedsheet/brown{
 	pixel_y = 13
@@ -1513,7 +1513,7 @@
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /obj/item/bedsheet/brown{
 	pixel_y = 13
@@ -1640,7 +1640,7 @@
 	pixel_y = 13
 	},
 /obj/item/bedsheet/brown{
-	layer = 3.0
+	layer = 3
 	},
 /obj/item/bedsheet/brown{
 	pixel_y = 13


### PR DESCRIPTION
# ЕРТ станции

Пулл включает 4 ЕРТ станции которые уже были в файлах у КМов, но не использовались. 
(UPP, WY, TWE, CLF)

# Почему

На замену обобщенной базе на админ уровне - теперь каждый из шаттлов использует свою базу.

# Пикчи
CLF
![image](https://github.com/RU-CMSS13/RU-CMSS13/assets/68549039/aed1fa9c-07e2-4608-a6bf-6ea9bc6c2c43)
TWE
![image](https://github.com/RU-CMSS13/RU-CMSS13/assets/68549039/ea970175-da2c-43d2-9737-a4ec70812954)
UPP
![image](https://github.com/RU-CMSS13/RU-CMSS13/assets/68549039/d5e9a24d-0326-4338-8482-4c9b65cfb4c5)
WY
![image](https://github.com/RU-CMSS13/RU-CMSS13/assets/68549039/2f2ba11e-5495-4a39-8f73-62f24dfdabcc)

# Чейнжлог
:cl:
mapadd: База UPP
mapadd: База TWE
mapadd: База CLF
mapadd: База WY
add: Вышеуказанные ЕРТ спавнятся на своих собственных базах.
/:cl:
