### PR TITLE
ребаланс атачей

### DIFF
--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -84,6 +84,17 @@
 	containername = "extended barrel attachment crate"
 	group = "Attachments"
 
+/datum/supply_packs/muzzle_heavy
+	name = "barrel charger attachment crate (x3)"
+	contains = list(
+		/obj/item/attachable/heavy_barrel,
+		/obj/item/attachable/heavy_barrel,
+	)
+	cost = 50
+	containertype = /obj/structure/closet/crate
+	containername = "heavy barrel attachment crate"
+	group = "Attachments"
+
 /datum/supply_packs/muzzle_compensator
 	name = "compensator attachment crate (x6)"
 	contains = list(

--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -90,7 +90,7 @@
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/heavy_barrel,
 	)
-	cost = 50
+	cost = 60
 	containertype = /obj/structure/closet/crate
 	containername = "heavy barrel attachment crate"
 	group = "Attachments"

--- a/code/datums/supply_packs/attachments.dm
+++ b/code/datums/supply_packs/attachments.dm
@@ -89,6 +89,7 @@
 	contains = list(
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/heavy_barrel,
+		/obj/item/attachable/heavy_barrel,
 	)
 	cost = 60
 	containertype = /obj/structure/closet/crate

--- a/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
+++ b/code/game/machinery/vending/vendor_types/crew/commanding_officer.dm
@@ -42,6 +42,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_commanding_officer, list(
 		list("Underbarrel Flamethrower", 15, /obj/item/attachable/attached_gun/flamer, null, VENDOR_ITEM_REGULAR),
 
 		list("BARREL ATTACHMENTS", 0, null, null, null),
+		list("Barrel Charger", 40, /obj/item/attachable/heavy_barrel, null, VENDOR_ITEM_RECOMMENDED),
 		list("Suppressor", 15, /obj/item/attachable/suppressor, null, VENDOR_ITEM_REGULAR),
 		list("Extended Barrel", 15, /obj/item/attachable/extended_barrel, null, VENDOR_ITEM_REGULAR),
 		list("Recoil Compensator", 15, /obj/item/attachable/compensator, null, VENDOR_ITEM_REGULAR),

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -290,7 +290,7 @@ Defined in conflicts.dm of the #defines folder.
 	flags_item = CAN_DIG_SHRAPNEL
 
 	attach_icon = "bayonet_a"
-	melee_mod = 20
+	melee_mod = 25
 	slot = "muzzle"
 	pixel_shift_x = 14 //Below the muzzle.
 	pixel_shift_y = 18
@@ -383,7 +383,8 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/extended_barrel/New()
 	..()
-	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
+	accuracy_mod = HIT_ACCURACY_MULT_TIER_2
+	damage_mod = BULLET_DAMAGE_MULT_TIER_1
 	velocity_mod = AMMO_SPEED_TIER_1
 
 /obj/item/attachable/heavy_barrel
@@ -575,6 +576,8 @@ Defined in conflicts.dm of the #defines folder.
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
 	scatter_mod = -SCATTER_AMOUNT_TIER_6
+	damage_mod = BULLET_DAMAGE_MULT_TIER_2
+	velocity_mod = AMMO_SPEED_TIER_1
 	delay_mod = FIRE_DELAY_TIER_7
 
 /obj/item/attachable/mateba/long/Attach(obj/item/weapon/gun/G)
@@ -594,6 +597,7 @@ Defined in conflicts.dm of the #defines folder.
 	..()
 	accuracy_mod = -HIT_ACCURACY_MULT_TIER_4
 	scatter_mod = SCATTER_AMOUNT_TIER_6
+	damage_mod = -BULLET_DAMAGE_MULT_TIER_2
 	delay_mod = -FIRE_DELAY_TIER_7
 
 /obj/item/attachable/mateba/short/Attach(obj/item/weapon/gun/G)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -384,7 +384,7 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/extended_barrel/New()
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_2
-	damage_mod = BULLET_DAMAGE_MULT_TIER_1
+	damage_mod = BULLET_DAMAGE_MULT_TIER_2
 	velocity_mod = AMMO_SPEED_TIER_1
 
 /obj/item/attachable/heavy_barrel
@@ -576,7 +576,7 @@ Defined in conflicts.dm of the #defines folder.
 	..()
 	accuracy_mod = HIT_ACCURACY_MULT_TIER_4
 	scatter_mod = -SCATTER_AMOUNT_TIER_6
-	damage_mod = BULLET_DAMAGE_MULT_TIER_2
+	damage_mod = BULLET_DAMAGE_MULT_TIER_3
 	velocity_mod = AMMO_SPEED_TIER_1
 	delay_mod = FIRE_DELAY_TIER_7
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -398,16 +398,17 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/heavy_barrel/New()
 	..()
 	accuracy_mod = -HIT_ACCURACY_MULT_TIER_3
-	damage_mod = BULLET_DAMAGE_MULT_TIER_6
+	damage_mod = BULLET_DAMAGE_MULT_TIER_10
+	velocity_mod = AMMO_SPEED_TIER_1
 	delay_mod = FIRE_DELAY_TIER_11
 
 	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_7
 
 /obj/item/attachable/heavy_barrel/Attach(obj/item/weapon/gun/G)
 	if(G.gun_category == GUN_CATEGORY_SHOTGUN)
-		damage_mod = BULLET_DAMAGE_MULT_TIER_1
+		damage_mod = BULLET_DAMAGE_MULT_TIER_3
 	else
-		damage_mod = BULLET_DAMAGE_MULT_TIER_6
+		damage_mod = BULLET_DAMAGE_MULT_TIER_10
 	..()
 
 /obj/item/attachable/compensator

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -304,7 +304,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bayonet/New()
 	..()
-	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_1
+	accuracy_unwielded_mod = -HIT_ACCURACY_MULT_TIER_2
 
 /obj/item/attachable/bayonet/upp_replica
 	name = "\improper Type 80 bayonet"


### PR DESCRIPTION

# About the pull request

Возвращает в игру БЧ, а так же небольшой реворк атачей.
# Explain why it's good for the game

Исправлены нелогичности с атачами.
Изменения:
БЧ возвращен в игру, заказать можно в карго за 6 тысяч (3 шт), либо в вендоре КО за много поинтов, отсутствует в обычных вендорах. БЧ был бафнут, потому что он был не нужен и только портил оружие, теперь же прибавка к урону 50% оправдывает огромнейшие дебафы.

БЧ увеличивает урон на 50%, дробовикам на 15%, ускоряет скорость пули как ext barrel.
Extended barrel Повышает урон на 10%, баф точности снижен с 20% до 10%.
Нож прикрепленный к винтовке наносит не 20 урона, а 25 как и обычный нож, нож на оружии дает -10% к точности заместо -5%.
Укороченное дуло матебы снижает урон на 10%, удлиненное дуло матебы увеличивает урон на 15%, а так же увеличивает скорость полета пули как ext barrel.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: Возврат БЧ в карго (за денюжку)
balance: Ребаланс атачей

/:cl:
