### PR TITLE
Lore-friendly synths, cargo turrets

### DIFF
--- a/code/modules/gear_presets/synths.dm
+++ b/code/modules/gear_presets/synths.dm
@@ -126,7 +126,8 @@
 
 /datum/equipment_preset/synth/survivor/load_race(mob/living/carbon/human/new_human)
 	//Switch to check client for synthetic generation preference, and set the subspecies of colonial synth
-	var/generation_selection = SYNTH_COLONY_GEN_ONE
+	new_human.set_species(SYNTH_COLONY_GEN_ONE)
+/*	var/generation_selection = SYNTH_COLONY_GEN_ONE
 	if(new_human.client?.prefs?.synthetic_type)
 		generation_selection = new_human.client.prefs.synthetic_type
 	switch(generation_selection)
@@ -138,6 +139,7 @@
 			new_human.set_species(SYNTH_COLONY_GEN_ONE)
 		else
 			new_human.set_species(SYNTH_COLONY)
+*/
 
 /datum/equipment_preset/synth/survivor/New()
 	. = ..()

--- a/colonialmarines.dme
+++ b/colonialmarines.dme
@@ -2427,6 +2427,7 @@ s// DM Environment file for colonialmarines.dme.
 #include "fray-marines\code\cm_tech\trees\xeno.dm"
 #include "fray-marines\code\datums\skills.dm"
 #include "fray-marines\code\datums\supply_packs\gear.dm"
+#include "fray-marines\code\datums\supply_packs\weapons.dm"
 #include "fray-marines\code\game\jobs\command\auxiliary\mech_crew.dm"
 #include "fray-marines\code\game\machinery\rechargestation.dm"
 #include "fray-marines\code\game\objects\items\storage\pouch.dm"

--- a/fray-marines/code/datums/supply_packs/weapons.dm
+++ b/fray-marines/code/datums/supply_packs/weapons.dm
@@ -1,0 +1,52 @@
+/datum/supply_packs/sentry_gun
+	contains = list(
+        /obj/item/defenses/handheld/sentry,
+	)
+	name = "UA 571-C Sentry Gun"
+	cost = 60
+	containertype = /obj/structure/closet/crate/supply
+	containername = "UA 571-C Sentry Gun (x1)"
+	group = "Weapons"
+
+/datum/supply_packs/sentry_flamer
+	contains = list(
+        /obj/item/defenses/handheld/sentry/flamer,
+	)
+	name = "UA 42-F Sentry Flamer"
+	cost = 80
+	containertype = /obj/structure/closet/crate/supply
+	containername = "UA 42-F Sentry Flamer (x1)"
+	group = "Weapons"
+
+/datum/supply_packs/tesla_coil
+	contains = list(
+        /obj/item/defenses/handheld/tesla_coil,
+	)
+	name = "21S Tesla Coil"
+	cost = 60
+	containertype = /obj/structure/closet/crate/supply
+	containername = "21S Tesla Coil (x1)"
+	group = "Weapons"
+
+/datum/supply_packs/planted_flag
+	contains = list(
+        /obj/item/defenses/handheld/planted_flag,
+	)
+	name = "JIMA Planted Flag"
+	cost = 40
+	containertype = /obj/structure/closet/crate/supply
+	containername = "JIMA Planted Flag (x1)"
+	group = "Weapons"
+
+/datum/supply_packs/mixed_sentry
+	contains = list(
+        /obj/item/defenses/handheld/planted_flag,
+		/obj/item/defenses/handheld/tesla_coil,
+		/obj/item/defenses/handheld/sentry/flamer,
+		/obj/item/defenses/handheld/sentry,
+	)
+	name = "Sentry mix, all in one"
+	cost = 200
+	containertype = /obj/structure/closet/crate/supply
+	containername = "JIMA Planted Flag (x1)\n21S Tesla Coil (x1)\nUA 42-F Sentry Flamer (x1)\nUA 571-C Sentry Gun (x1)"
+	group = "Weapons"


### PR DESCRIPTION

# About the pull request

Добавлены турели в карго:
Флаг (4к),
Обычная турель (6к)
Тесла (6к)
Огненная турель (8к)
Микс турелей, всё в одном (20к) Имеет все турели в количестве 1 единицы.

Колониальные синтетики теперь лорно-заявленные первые поколения всегда

# Explain why it's good for the game

Больше фортификаций инженерам, синтетики-сурвы теперь лор-френдли, не будет каких то тупеньких третьих поколений на колонии.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

:cl:
add: Турели теперь можно купить в карго
qol: Синтетики-сурвы теперь лор-френдли первое поколение!
/:cl:
