### PR TITLE
Увеличение делэя до конца раунда при отсутствии квины, а также отключение таймлоков на неё

### DIFF
--- a/code/game/gamemodes/cm_process.dm
+++ b/code/game/gamemodes/cm_process.dm
@@ -1,5 +1,5 @@
 
-#define QUEEN_DEATH_COUNTDOWN  10 MINUTES //10 minutes. Can be changed into a variable if it needs to be manipulated later.
+#define QUEEN_DEATH_COUNTDOWN  15 MINUTES //10 minutes. Can be changed into a variable if it needs to be manipulated later.
 
 #define MODE_INFESTATION_X_MAJOR "Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR "Marine Major Victory"

--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -25,3 +25,4 @@ AddTimelock(/datum/job/antag/xenos/queen, list(
 	JOB_T3_ROLES = 1 HOURS,
 ))
 */
+

--- a/code/game/jobs/job/antag/xeno/queen.dm
+++ b/code/game/jobs/job/antag/xeno/queen.dm
@@ -18,8 +18,10 @@
 	to_chat(new_queen, "<B>You should start by building a hive core.</B>")
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';Hello my children!')")
 
+/*
 AddTimelock(/datum/job/antag/xenos/queen, list(
 	JOB_XENO_ROLES = 3 HOURS,
 	JOB_DRONE_ROLES = 1 HOURS,
 	JOB_T3_ROLES = 1 HOURS,
 ))
+*/


### PR DESCRIPTION
Давайте так, мы все понимаем, зачем этот таймер был увеличен. На данный момент, когда онлайн у нас едва ли достигает 15-и игроков в прайм-тайм - это очень сильно мешает. Лярва, которая чаще всего спавнится в гордом одиночестве, банально не успевает эволвнуть в квину вовремя, а за саму квину почти никто зайти моментально не может - ибо таймлок. Да и ксеномейнеры, собственно, в игру в принципе практически не заходят, увы!

Этот ПР призван решить обе этих проблемы, позволив кому угодно джоиниться за королеву, и в случае, если таких кандидатов по-прежнему не будет - даёт больше времени оставшимся на эволв.