### PR TITLE
Делаем ёжиков более скиллозависимыми

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ravager/ravager_abilities.dm
@@ -121,10 +121,10 @@
 	xeno_cooldown = 9 SECONDS + 2.5 SECONDS // Left operand is the actual CD, right operand is the buffer for the shield duration
 
 	// Config values
-	var/shield_duration = 25 // Shield lasts 2.5 seconds by default.
+	var/shield_duration = 15 // Shield lasts 1.5 seconds by default.
 	var/shield_amount = 500 // Shield HP amount
-	var/shield_shrapnel_amount = 7  // How much shrapnel each shield hit should spawn
-	var/shard_cost = 150 // Minimum spikes to use this ability
+	var/shield_shrapnel_amount = 6  // How much shrapnel each shield hit should spawn
+	var/shard_cost = 200 // Minimum spikes to use this ability
 	var/shield_active = FALSE // Is our shield active.
 	var/real_hp_per_shield_hp = 0.5 // How many real HP we get for each shield HP
 

--- a/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/hedgehog.dm
+++ b/code/modules/mob/living/carbon/xenomorph/mutators/strains/ravager/hedgehog.dm
@@ -42,7 +42,7 @@
 	name = "Hedgehog Ravager Behavior Delegate"
 
 	// Shard config
-	var/max_shards = 300
+	var/max_shards = 250
 	var/shard_gain_onlife = 5
 	var/shards_per_projectile = 10
 	var/shards_per_slash = 15


### PR DESCRIPTION
# About the pull request

Делаем ёжиков не метой, пробуем что-то делать, популяризировать берсеркеров и стандартных равагеров

# Explain why it's good for the game

Ежи в наших реалиях просто ксеноморф для новичков который не требует скилла и является топ 1 в выборе из-за новеньких игроков. Если на оффах вперёд пускают ветеранов, то у нас такого нету, надо что то делать с мутацией, если будет слишком сильным нерфом, то будем откатывать и переделывать.
Повышаю стоимость щита и уменьшаю запас шардов для того что бы сделать из ёжика не убивателем всего и вся, а того кто может сейвить своим большим щитом убегающих ксеноморфов и это будет последний козырь в его рукаве.
С уменьшением запаса шардов так же и уменьшаю максимальный армор ёжику, потому что с нашим балансом патрон, не сказать что оно наносило хоть какой то урон ёжику с полным запасом шардов.


# Testing Photographs and Procedure


# Changelog

balance: Длительность щита равагера уменьшена с 2.5 секунд до 1.5 секунды
balance: Стоимость щита увеличена с 150 костей до 200
balance: Количество шардов у ежа уменьшено с 300 до 250

:cl:
add: Added something
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
spellcheck: fixed a few typos
ui: changed something relating to user interfaces
code: changed some code
refactor: refactored some code
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
mapadd: added a new map or section to a map
maptweak: tweaked a map
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
