### PR TITLE
QoL for MK1, cnaper-issue

### DIFF
--- a/fray-marines/code/datums/supply_packs/ammo.dm
+++ b/fray-marines/code/datums/supply_packs/ammo.dm
@@ -1,0 +1,19 @@
+/datum/supply_packs/MK1AP
+	contains = list(
+		/obj/item/ammo_box/magazine/mk1/ap
+	)
+	name = "Magazine box (M41A MK1, 8x AP mags)"
+	cost = 30
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "Magazine box (M41A MK1, 8x AP mags)"
+	group = "Ammo"
+
+/datum/supply_packs/MK1
+	contains = list(
+		/obj/item/ammo_box/magazine/mk1
+	)
+	name = "Magazine box (M41A MK1, 8x regular mags)"
+	cost = 30
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "Magazine box (M41A MK1, 8x regular mags)"
+	group = "Ammo"


### PR DESCRIPTION
# About the pull request

Изменил турелькам в карго цену, примерно такую, дабы на самом старте можно было купить пак из четырёх. (Кнапер/Эклипс запросы ишшуе)
Добавил покупку магазинов для МК1 (В том числе и АП) в карго

# Explain why it's good for the game

Ну это просто удобнее для тех кто пользуется МК1, они могут докупить в карго дополнительные магазины, а не хранить их как зеницу ока, ну и если есть более 2-ух любителей старых винтовок, они не будут страдать от нехватки магазинов.


# Changelog

:cl:

qol: Добавлены магазины МК1 в карго
balance: Уменьшена цена на турели

/:cl:

