### PR TITLE
Spare fuel cells for reactors

### DIFF
--- a/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
+++ b/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
@@ -18916,6 +18916,7 @@
 /obj/structure/machinery/alarm/almayer{
 	dir = 1
 	},
+/obj/item/fuel_cell,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -19323,6 +19324,7 @@
 /area/almayer/engineering/lower/engine_core)
 "bJQ" = (
 /obj/structure/surface/table/almayer,
+/obj/item/fuel_cell,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
@@ -38742,6 +38744,7 @@
 	name = "General Listening Channel";
 	pixel_y = 28
 	},
+/obj/item/fuel_cell,
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},

--- a/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
+++ b/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
@@ -12485,6 +12485,11 @@
 	},
 /area/almayer/hallways/upper/stern_hallway)
 "aWk" = (
+/obj/structure/machinery/cm_vending/gear/executive_officer{
+	pixel_y = 18;
+	pixel_x = -1;
+	density = 0
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -19139,7 +19144,8 @@
 	id = "CIC_armory";
 	name = "CIC Armory Control";
 	req_one_access_txt = "1;4";
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /obj/item/device/cotablet{
 	pixel_x = -1;


### PR DESCRIPTION

# About the pull request
Added spare fuel cells for reactors
<!-- Remove this text and explain what the purpose of your PR is.
Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game
If for some reason all reactors are broken and cells are dead. marines can use spare ones
# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

![image](https://github.com/RU-CMSS13/RU-CMSS13/assets/87248908/97cbfc3b-b326-459e-9efe-6e12409aed0d)

</details>


# Changelog
:cl:
add: Added spare fuel cells
/:cl:
