### PR TITLE
Реворк М46С

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -427,7 +427,8 @@
 
 /obj/item/weapon/gun/rifle/m46c
 	name = "\improper M46C pulse rifle"
-	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Back issue only. Uses standard MK1 & MK2 rifle magazines."
+	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Commander version. Uses standard MK1 & MK2 rifle magazines. Use against any threats."
+	desc_lore = "M46 - New combat platform, developed in 2176 by ARMAT and WY Combat Division, result of the U.P.C (Universal Combat Platform) project. The C - Commander version includes built in Barrel Charger 3.0, Quick Fire system and ID lock
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
 	icon_state = "m46c"
 	item_state = "m46c"
@@ -460,8 +461,6 @@
 		/obj/item/attachable/reflex,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/extended_barrel,
-		/obj/item/attachable/heavy_barrel,
-		/obj/item/attachable/heavy_barrel/upgraded,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/verticalgrip,
 		/obj/item/attachable/angledgrip,
@@ -527,15 +526,15 @@
 
 /obj/item/weapon/gun/rifle/m46c/set_gun_config_values()
 	..()
-	set_fire_delay(FIRE_DELAY_TIER_9)
+	set_fire_delay(FIRE_DELAY_TIER_LMG)
 	set_burst_amount(BURST_AMOUNT_TIER_4)
-	set_burst_delay(FIRE_DELAY_TIER_12)
+	set_burst_delay(FIRE_DELAY_TIER_11)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_4
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_8
 	scatter = SCATTER_AMOUNT_TIER_8
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_8
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_3
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_8
 	recoil_unwielded = RECOIL_AMOUNT_TIER_2
 	fa_max_scatter = SCATTER_AMOUNT_TIER_7
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -428,7 +428,7 @@
 /obj/item/weapon/gun/rifle/m46c
 	name = "\improper M46C pulse rifle"
 	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Commander version. Uses standard MK1 & MK2 rifle magazines. Use against any threats."
-	desc_lore = "M46 - New combat platform, developed in 2176 by ARMAT and WY Combat Division, result of the U.P.C (Universal Combat Platform) project. The C - Commander version includes built in Barrel Charger 3.0, Quick Fire system and ID lock."
+	desc_lore = "M46 - New combat platform, developed in 2176 by ARMAT and WY Combat Division, result of the U.C.P (Universal Combat Platform) project. The C - Commander version includes built in Barrel Charger 3.0, Quick Fire system and ID lock."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
 	icon_state = "m46c"
 	item_state = "m46c"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -428,7 +428,7 @@
 /obj/item/weapon/gun/rifle/m46c
 	name = "\improper M46C pulse rifle"
 	desc = "A prototype M46C, an experimental rifle platform built to outperform the standard M41A. Commander version. Uses standard MK1 & MK2 rifle magazines. Use against any threats."
-	desc_lore = "M46 - New combat platform, developed in 2176 by ARMAT and WY Combat Division, result of the U.P.C (Universal Combat Platform) project. The C - Commander version includes built in Barrel Charger 3.0, Quick Fire system and ID lock
+	desc_lore = "M46 - New combat platform, developed in 2176 by ARMAT and WY Combat Division, result of the U.P.C (Universal Combat Platform) project. The C - Commander version includes built in Barrel Charger 3.0, Quick Fire system and ID lock."
 	icon = 'icons/obj/items/weapons/guns/guns_by_faction/uscm.dmi'
 	icon_state = "m46c"
 	item_state = "m46c"


### PR DESCRIPTION
# About the pull request

Новая М46С, реворкнул для балансировки, тк щас это имба.
Изменения: Понерфлен бурст, теперь он не такой ультимативный как раньше, 4 пули, скорость бурста как у базовой МК2.
Скорострельность обычного режима стрельбы изменена, теперь она 300 выстрелов в секунду (5 пуль, скорострел как у ХПР).
Урон увеличен до значений, будто нацеплен барел чарджер (56 обычная пуля, 42 бронебойная и тд).
Никакой БЧ нацепить больше нельзя.
Добавлено ЛОР описание М46С.

(Проверил, автофаер не сломан, все корректно).
# Explain why it's good for the game
Сравним значения М46С нынешней и этой новой.
1 - Очередь, за секунду М46С была способна сделать 2 бурста по 4 выстрела каждый, итого 8 пуль в секунду. 46*8 = 368 урона в секунду, плюс это очередь, если нацелиться на спрайт ксена - куда бы он не пошел - каждая пуля попадет ровно в него, даже если игрок уже не целится и ксен мансит, пуля не попадет только если ксен забежал за укрытие, грубо говоря это автонаводка на минималках. Обычный режим стрельбы был бесполезен из за крайне низкого ДПСа, что, как бы, намекало игрокам, что нужно использовать эту винтовку только в бурст режиме.
Все и так знают, на что способна М46С со своим бурстом - это тупо анигиляция всех игроков на любой ксене или любой вражеской роли, почти без шансов.

2 - Новая, очередь теперь обычная, не такая ультимативная, а обычный скорострел 300 как у ХПР. Сравниваем, 56*5 = 280 урона в секунду, это синг фаер или автофаер скорострел, то есть игроку придеться ПОСТОЯННО целиться по ксене или врагу, чтобы попадать, а не 1 раз кликнул по спрайту и далее абсолютно вся очередь летит во врага, чтобы он не предпринимал, вообщем, распил все еще мощный, но не доведен до автоматизма типа 1-3 раза кликнул и ксен обмяк и сдох (независимо от тира и брони).

Как итог получаем все еще отличную винтовку, но не винтовку, которая за тебя воюет, а тебе лишь остается кликать ЛКМ и смотреть, как ксены умирают со скоростью света.
Это сводит на нет старания ксен, когда они превозмогают всем ульем, выбивают маров с земли, а на корабле встречают КО, который в соло выпиливает вообще всех.

Ну и собсна новый бурст и скорострел без бурста (синг и автофаер), это привносит разнообразие, тк игрок теперь может выбрать, стрелять бурстом, или обычным режимом, оба режима хороши, в отличии от старого, где было очевидно, что нужно брать исключительно бурст.


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
balance: М46С очередь понижена до обычной очереди МК2, урон увеличен, скорострельность в обычном режиме увеличена до уровня ХПР.
/:cl:
