### PR TITLE
[Map Tweak] Brig & MP's Bunks and little fix airlock

### DIFF
--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -262,6 +262,9 @@
 /area/almayer/shipboard/brig/general_equipment
 	name = "\improper Brig General Equipment"
 
+/area/almayer/shipboard/brig/office
+	name = "\improper Brig Office"
+
 /area/almayer/shipboard/brig/evidence_storage
 	name = "\improper Brig Evidence Storage"
 

--- a/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
+++ b/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
@@ -53678,7 +53678,9 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/marine{
 	dir = 2;
-	name = "Squad Preparations"
+	name = "Squad Preparations";
+	req_access = list(9);
+	req_one_access = list(2,21)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -57482,7 +57484,9 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/marine{
 	dir = 2;
-	name = "Squad Preparations"
+	name = "Squad Preparations";
+	req_access = list(9);
+	req_one_access = list(2,21)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -59173,7 +59177,9 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/marine{
 	dir = 2;
-	name = "Squad Preparations"
+	name = "Squad Preparations";
+	req_access = list(9);
+	req_one_access = list(2,21)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -74632,15 +74638,6 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/charlie)
-"uPa" = (
-/obj/structure/machinery/camera/autoname/almayer{
-	name = "ship-grade camera"
-	},
-/turf/open/floor/almayer{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/almayer/shipboard/brig/office)
 "uPr" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -82646,7 +82643,9 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/marine{
 	dir = 2;
-	name = "Squad Preparations"
+	name = "Squad Preparations";
+	req_access = list(9);
+	req_one_access = list(2,21)
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -93710,7 +93709,7 @@ oCL
 rvu
 fuB
 clB
-uPa
+wNi
 fXc
 fXc
 ckS

--- a/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
+++ b/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
@@ -112,7 +112,7 @@
 /area/almayer/hallways/lower/repair_bay)
 "aau" = (
 /turf/closed/wall/almayer/outer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "aav" = (
 /obj/vehicle/powerloader,
 /obj/structure/platform{
@@ -3611,7 +3611,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "anb" = (
 /obj/structure/machinery/conveyor{
 	id = "lower_garbage"
@@ -4340,7 +4340,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "apk" = (
 /obj/effect/step_trigger/teleporter_vector{
 	name = "Almayer_Down1";
@@ -4372,7 +4372,7 @@
 	icon_state = "NW-out"
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "app" = (
 /obj/structure/barricade/handrail{
 	dir = 1;
@@ -4388,7 +4388,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "apr" = (
 /obj/structure/machinery/light{
 	unacidable = 1;
@@ -4417,7 +4417,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "apu" = (
 /turf/open/floor/almayer{
 	dir = 10;
@@ -4792,7 +4792,7 @@
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "aqB" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -5259,7 +5259,7 @@
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "asf" = (
 /obj/structure/janitorialcart,
 /obj/structure/machinery/light/small{
@@ -6466,7 +6466,7 @@
 /turf/open/floor/almayer{
 	icon_state = "mono"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "ava" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W"
@@ -6784,7 +6784,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "avV" = (
 /obj/item/reagent_container/food/snacks/grown/poppy{
 	pixel_x = 4;
@@ -6933,7 +6933,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "awt" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -6993,7 +6993,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "awB" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
@@ -7117,7 +7117,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "axa" = (
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin3"
@@ -7508,7 +7508,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "ayw" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -9105,7 +9105,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "aEm" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/working_joe{
@@ -9723,7 +9723,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "aGW" = (
 /turf/open/floor/almayer{
 	icon_state = "sterile_green_side"
@@ -10339,7 +10339,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "aJD" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -11585,7 +11585,7 @@
 	name = "\improper Combat Information Center Blast Door"
 	},
 /turf/open/floor/plating,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "aRr" = (
 /obj/structure/machinery/recharge_station,
 /obj/structure/prop/invuln/overhead_pipe{
@@ -12522,7 +12522,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "aWr" = (
 /obj/structure/window/framed/almayer/hull,
 /turf/open/floor/plating,
@@ -12623,7 +12623,7 @@
 "aWR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "aWS" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_17";
@@ -16419,7 +16419,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "buc" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -16551,7 +16551,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "bvb" = (
 /obj/structure/window/reinforced/toughened{
 	pixel_y = -9
@@ -19558,7 +19558,7 @@
 /area/almayer/engineering/lower/engine_core)
 "bLb" = (
 /turf/closed/wall/almayer/reinforced,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "bLc" = (
 /obj/structure/machinery/light,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -21149,7 +21149,7 @@
 	dir = 6
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "bTx" = (
 /turf/open/floor/wood/ship,
 /area/almayer/shipboard/sea_office)
@@ -22128,7 +22128,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "bZc" = (
 /obj/structure/sign/safety/nonpress_0g{
 	pixel_x = -16
@@ -22146,7 +22146,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "bZi" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -22773,7 +22773,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "cce" = (
 /obj/structure/machinery/door/airlock/almayer/engineering{
 	dir = 2;
@@ -22930,6 +22930,17 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/hangar)
+"ccL" = (
+/obj/structure/machinery/vending/snack{
+	pixel_y = 2
+	},
+/obj/structure/sign/safety/bathunisex{
+	pixel_x = 32
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "ccO" = (
 /obj/structure/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -23035,7 +23046,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "cdn" = (
 /obj/effect/landmark/ert_spawns/distress_cryo,
 /obj/effect/landmark/late_join,
@@ -23501,7 +23512,7 @@
 	dir = 6;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ciN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -23791,7 +23802,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ckX" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -23869,6 +23880,9 @@
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
+"clB" = (
+/turf/closed/wall/almayer/reinforced,
+/area/almayer/shipboard/brig/office)
 "clC" = (
 /obj/structure/stairs,
 /obj/structure/machinery/light{
@@ -24748,6 +24762,12 @@
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
+"cuW" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "cvb" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 6
@@ -25299,7 +25319,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "cFP" = (
 /obj/structure/sign/safety/outpatient{
 	pixel_x = -17;
@@ -25467,7 +25487,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "cJA" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -25655,7 +25675,7 @@
 	dir = 5
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "cNH" = (
 /obj/structure/machinery/door/poddoor/shutters/almayer/containment{
 	id = "Containment Cell 4";
@@ -25672,9 +25692,7 @@
 	},
 /area/almayer/medical/containment/cell/cl)
 "cNT" = (
-/obj/structure/machinery/door/airlock/almayer/marine{
-	dir = 2
-	},
+/obj/structure/machinery/door/airlock/almayer/marine,
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
@@ -25694,7 +25712,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "cOe" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -25857,6 +25875,16 @@
 	},
 /turf/open/floor/wood/ship,
 /area/almayer/living/basketball)
+"cRX" = (
+/obj/structure/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/office)
 "cSk" = (
 /obj/structure/machinery/door/window/southleft,
 /turf/open/floor/almayer{
@@ -26123,7 +26151,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "cWt" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -26525,7 +26553,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "dck" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
@@ -28283,7 +28311,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "dGw" = (
 /obj/effect/step_trigger/clone_cleaner,
 /obj/effect/decal/warning_stripes{
@@ -28948,6 +28976,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/medical/morgue)
+"dSO" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 1;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	dir = 5;
+	icon_state = "plating"
+	},
+/area/almayer/squads/req)
 "dSX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29817,7 +29855,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "egS" = (
 /obj/structure/closet,
 /obj/item/clothing/ears/earmuffs,
@@ -29882,6 +29920,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/living/port_emb)
+"eie" = (
+/obj/structure/surface/rack,
+/obj/item/tool/crowbar,
+/obj/item/tool/crowbar,
+/obj/item/clothing/glasses/welding{
+	layer = 3.6;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "eim" = (
 /obj/structure/pipes/vents/pump{
 	dir = 1
@@ -29952,7 +30003,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "eiP" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -30242,7 +30293,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "enN" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -30597,7 +30648,7 @@
 	dir = 9
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "evk" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/food/snacks/wrapped/barcardine{
@@ -31498,6 +31549,14 @@
 	icon_state = "plate"
 	},
 /area/almayer/shipboard/panic)
+"eND" = (
+/obj/structure/machinery/door/airlock/almayer/security/autoname{
+	dir = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "test_floor4"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "eNE" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -31566,7 +31625,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "eOW" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/sentencing,
@@ -31585,7 +31644,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "ePs" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	dir = 4;
@@ -31696,7 +31755,7 @@
 	name = "\improper Combat Information Center Blast Door"
 	},
 /turf/open/floor/plating,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "eRy" = (
 /obj/structure/machinery/door/airlock/multi_tile/almayer/medidoor{
 	dir = 2;
@@ -32661,7 +32720,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "fks" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -32718,6 +32777,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/maint/hull/upper/s_bow)
+"flJ" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/office)
 "flP" = (
 /obj/structure/machinery/camera/autoname/almayer{
 	dir = 4;
@@ -32863,7 +32925,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "fnI" = (
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -33243,7 +33305,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "fuB" = (
 /obj/structure/machinery/light/small,
 /obj/structure/largecrate/random/barrel/green,
@@ -34094,7 +34156,7 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "fJA" = (
 /obj/structure/coatrack,
 /obj/structure/sign/poster/clf{
@@ -34769,6 +34831,9 @@
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/lower/workshop)
+"fXc" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/almayer/shipboard/brig/office)
 "fXd" = (
 /obj/structure/machinery/light/small{
 	dir = 4
@@ -35522,7 +35587,7 @@
 	name = "\improper Combat Information Center Blast Door"
 	},
 /turf/open/floor/plating,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "gkz" = (
 /obj/structure/machinery/vending/cigarette,
 /turf/open/floor/almayer{
@@ -35844,7 +35909,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "grw" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -37055,6 +37120,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/starboard_aft_hallway)
+"gNV" = (
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/office)
 "gOe" = (
 /obj/structure/machinery/light{
 	dir = 1
@@ -37279,7 +37350,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "gTH" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/computer/skills{
@@ -37682,6 +37753,14 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/upper/aft_hallway)
+"hbs" = (
+/obj/structure/machinery/vending/cola{
+	pixel_y = 2
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "hbz" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -38226,6 +38305,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/squads/alpha)
+"hmO" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/clothing/head/headset{
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/obj/item/device/flashlight/lamp{
+	pixel_y = 11
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "hmR" = (
 /obj/structure/machinery/cm_vending/gear/smartgun{
 	pixel_y = -31;
@@ -39454,7 +39546,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "hKO" = (
 /obj/structure/pipes/vents/scrubber{
 	dir = 4
@@ -39594,7 +39686,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "hNF" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -40266,7 +40358,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "iag" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/hand_labeler,
@@ -40624,7 +40716,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "igD" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -40836,7 +40928,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ikU" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -40888,6 +40980,15 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer,
 /area/almayer/lifeboat_pumps/south1)
+"ilQ" = (
+/obj/item/clothing/mask/rebreather/scarf,
+/obj/structure/closet/secure_closet/personal/cabinet{
+	req_access = null
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "imf" = (
 /obj/structure/supply_drop/alpha,
 /turf/open/floor/plating,
@@ -40964,7 +41065,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ioU" = (
 /turf/closed/wall/almayer,
 /area/almayer/command/securestorage)
@@ -41035,7 +41136,7 @@
 "iqn" = (
 /obj/structure/pipes/standard/manifold/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "iqo" = (
 /obj/structure/flora/pottedplant{
 	icon_state = "pottedplant_22"
@@ -41251,7 +41352,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "iuy" = (
 /obj/structure/window/framed/almayer,
 /obj/structure/machinery/door/firedoor/border_only/almayer{
@@ -44244,7 +44345,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "jCB" = (
 /obj/structure/surface/table/almayer,
 /obj/item/ashtray/glass{
@@ -44477,7 +44578,7 @@
 	dir = 8;
 	icon_state = "redcorner"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "jHC" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -45071,7 +45172,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "jUn" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/structure/machinery/door/window/southleft{
@@ -45153,7 +45254,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "jVt" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
@@ -45874,7 +45975,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "kkt" = (
 /obj/structure/surface/table/almayer,
 /obj/item/book/manual/marine_law,
@@ -46026,6 +46127,12 @@
 	icon_state = "plate"
 	},
 /area/almayer/hallways/lower/port_fore_hallway)
+"koo" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "koz" = (
 /obj/structure/surface/table/almayer,
 /obj/item/device/lightreplacer{
@@ -46656,6 +46763,13 @@
 	icon_state = "silvercorner"
 	},
 /area/almayer/shipboard/brig/cic_hallway)
+"kzW" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "kAh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W";
@@ -48363,7 +48477,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "ley" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48922,6 +49036,15 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/lower/starboard_umbilical)
+"lqX" = (
+/obj/structure/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/almayer{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/office)
 "lqZ" = (
 /obj/structure/machinery/floodlight/landing,
 /turf/open/floor/almayer{
@@ -49113,7 +49236,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "luu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49230,6 +49353,9 @@
 	icon_state = "mono"
 	},
 /area/almayer/lifeboat_pumps/north1)
+"lvD" = (
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "lvL" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/light{
@@ -49354,7 +49480,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "lyk" = (
 /obj/structure/sign/safety/storage{
 	pixel_x = -17
@@ -49397,7 +49523,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "lzA" = (
 /obj/structure/machinery/sleep_console{
 	dir = 8
@@ -49521,7 +49647,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "lCS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out";
@@ -50074,7 +50200,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "lNy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -50809,7 +50935,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "mdW" = (
 /obj/structure/surface/table/reinforced/almayer_B,
 /obj/effect/decal/warning_stripes{
@@ -51497,7 +51623,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "mqu" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 10
@@ -52578,7 +52704,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/closed/wall/almayer/reinforced,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "mKh" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -52790,6 +52916,12 @@
 	icon_state = "sterile"
 	},
 /area/almayer/medical/upper_medical)
+"mNN" = (
+/obj/structure/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "mNR" = (
 /obj/structure/surface/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -53335,7 +53467,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "mXX" = (
 /obj/structure/surface/table/almayer,
 /obj/item/tool/weldpack,
@@ -53544,8 +53676,9 @@
 	icon_state = "N";
 	pixel_y = 1
 	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/marine/shared{
-	dir = 2
+/obj/structure/machinery/door/airlock/almayer/marine{
+	dir = 2;
+	name = "Squad Preparations"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -54084,7 +54217,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "nne" = (
 /turf/open/floor/almayer{
 	dir = 1;
@@ -54473,7 +54606,7 @@
 	req_one_access_txt = "24;31"
 	},
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ntr" = (
 /obj/structure/machinery/portable_atmospherics/hydroponics,
 /obj/item/seeds/goldappleseed,
@@ -54882,6 +55015,15 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_m_p)
+"nBn" = (
+/obj/structure/machinery/prop/almayer/computer{
+	dir = 8
+	},
+/obj/structure/surface/table/reinforced/black,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "nBo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54930,7 +55072,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "nBW" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -55213,7 +55355,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "nHm" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -55793,7 +55935,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "nSS" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -56926,7 +57068,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "oqx" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -57187,7 +57329,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "osV" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/attachment,
@@ -57278,7 +57420,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ouW" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -57338,8 +57480,9 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/marine/shared{
-	dir = 2
+/obj/structure/machinery/door/airlock/almayer/marine{
+	dir = 2;
+	name = "Squad Preparations"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -58181,7 +58324,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "oPy" = (
 /obj/structure/machinery/cm_vending/sorted/cargo_guns/pilot_officer{
 	density = 0;
@@ -58718,7 +58861,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "paa" = (
 /obj/structure/machinery/iv_drip,
 /turf/open/floor/almayer{
@@ -58744,7 +58887,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "paA" = (
 /obj/structure/machinery/vending/cola,
 /turf/open/floor/almayer{
@@ -58877,7 +59020,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "pcS" = (
 /obj/structure/sign/safety/escapepod{
 	pixel_x = -17;
@@ -59028,8 +59171,9 @@
 /obj/effect/decal/warning_stripes{
 	icon_state = "S"
 	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/marine/shared{
-	dir = 2
+/obj/structure/machinery/door/airlock/almayer/marine{
+	dir = 2;
+	name = "Squad Preparations"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -59228,7 +59372,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "plx" = (
 /obj/structure/machinery/cm_vending/clothing/senior_officer{
 	req_access = list(26)
@@ -59281,7 +59425,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "pma" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /obj/structure/disposalpipe/segment{
@@ -60024,7 +60168,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "pzi" = (
 /obj/structure/prop/invuln/overhead_pipe{
 	pixel_x = 12
@@ -60808,7 +60952,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redcorner"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "pON" = (
 /turf/open/floor/almayer/uscm/directional{
 	dir = 8
@@ -60860,7 +61004,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "pQq" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "SW-out"
@@ -61243,11 +61387,22 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "pWN" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
 /area/almayer/living/pilotbunks)
+"pWT" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/structure/machinery/status_display{
+	pixel_y = -29
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "pWW" = (
 /obj/structure/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -61352,7 +61507,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "pYX" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -61751,7 +61906,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "qga" = (
 /obj/structure/machinery/space_heater,
 /obj/structure/sign/safety/maint{
@@ -62065,7 +62220,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "qmD" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 5
@@ -62103,6 +62258,10 @@
 "qmX" = (
 /obj/structure/toilet{
 	dir = 1
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -62326,7 +62485,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "qqW" = (
 /turf/closed/wall/almayer,
 /area/almayer/maint/hull/lower/p_bow)
@@ -62338,7 +62497,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "qru" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
@@ -62802,7 +62961,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "qAe" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
@@ -63634,7 +63793,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "qOX" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -63786,6 +63945,15 @@
 	icon_state = "redfull"
 	},
 /area/almayer/squads/alpha_delta_shared)
+"qSJ" = (
+/obj/effect/landmark/start/police,
+/obj/structure/machinery/power/apc/almayer{
+	dir = 8
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "qSK" = (
 /obj/item/stack/sheet/metal{
 	layer = 2.9;
@@ -64154,6 +64322,24 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/lower/vehiclehangar)
+"qZP" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/clothing/head/headset{
+	pixel_y = -7;
+	pixel_x = -8
+	},
+/obj/item/clothing/head/helmet/marine/pilot{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/clothing/mask/rebreather/scarf,
+/obj/item/device/camera{
+	pixel_x = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "rac" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/pipes/standard/manifold/hidden/supply,
@@ -64171,7 +64357,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "rav" = (
 /obj/structure/platform{
 	dir = 4
@@ -64813,7 +64999,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "rmD" = (
 /obj/structure/machinery/light/small{
 	dir = 8
@@ -65500,7 +65686,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "rzn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -65642,7 +65828,7 @@
 	dir = 9;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "rCf" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "S";
@@ -67304,7 +67490,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "siy" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -67421,6 +67607,16 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/shipboard/sea_office)
+"skp" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/structure/machinery/computer/emails{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "sky" = (
 /obj/effect/step_trigger/clone_cleaner,
 /turf/open/floor/plating/almayer{
@@ -67632,7 +67828,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "soK" = (
 /obj/structure/surface/rack,
 /obj/effect/spawner/random/powercell,
@@ -67813,7 +68009,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "srW" = (
 /obj/structure/machinery/landinglight/ds1/delaythree{
 	dir = 8
@@ -68036,7 +68232,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "swt" = (
 /turf/open/floor/almayer{
 	icon_state = "greencorner"
@@ -68127,7 +68323,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "szE" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "NE-out";
@@ -68143,7 +68339,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "sAC" = (
 /turf/open/floor/almayer{
 	icon_state = "orange"
@@ -68351,7 +68547,7 @@
 	name = "\improper Privacy Shutters"
 	},
 /turf/open/floor/plating,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "sFD" = (
 /obj/structure/surface/table/almayer,
 /obj/item/facepaint/green,
@@ -68844,7 +69040,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "sQX" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/item/device/camera_film{
@@ -69081,6 +69277,19 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
+"sWF" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	dir = 8;
+	icon_state = "plating_striped"
+	},
+/area/almayer/squads/req)
 "sWW" = (
 /obj/structure/machinery/flasher{
 	alpha = 1;
@@ -69268,7 +69477,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "sYP" = (
 /obj/structure/reagent_dispensers/fueltank/custom,
 /turf/open/floor/almayer{
@@ -69469,7 +69678,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tdx" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 9
@@ -69651,6 +69860,10 @@
 	icon_state = "green"
 	},
 /area/almayer/hallways/lower/port_midship_hallway)
+"tgv" = (
+/obj/structure/pipes/standard/simple/hidden/supply,
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "tgE" = (
 /obj/structure/platform{
 	dir = 4;
@@ -69940,12 +70153,12 @@
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "tlu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tlx" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -69969,7 +70182,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "tmg" = (
 /obj/structure/surface/table/almayer,
 /obj/item/reagent_container/hypospray,
@@ -70008,7 +70221,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tmA" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -70846,7 +71059,7 @@
 /turf/open/floor/almayer{
 	icon_state = "cargo"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "tAR" = (
 /obj/structure/machinery/cryopod/right{
 	pixel_y = 6
@@ -70907,7 +71120,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "tCR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
@@ -71088,7 +71301,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tGh" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -28
@@ -71159,7 +71372,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tHP" = (
 /turf/open/floor/almayer{
 	dir = 8;
@@ -71312,7 +71525,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tJy" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -71321,7 +71534,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tJR" = (
 /obj/structure/machinery/vending/cigarette,
 /obj/structure/sign/safety/medical{
@@ -72101,7 +72314,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "tZs" = (
 /obj/structure/machinery/door/airlock/almayer/maint{
 	dir = 1;
@@ -72768,6 +72981,10 @@
 /area/almayer/squads/charlie)
 "uly" = (
 /obj/structure/bed/stool,
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_state = "plating_striped"
@@ -72939,7 +73156,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "upe" = (
 /obj/structure/machinery/cm_vending/sorted/tech/electronics_storage,
 /turf/open/floor/almayer{
@@ -73442,7 +73659,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "uwv" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room/notunnel)
@@ -73668,7 +73885,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "uAj" = (
 /obj/structure/bed/chair,
 /obj/structure/machinery/light{
@@ -74415,6 +74632,15 @@
 	icon_state = "cargo"
 	},
 /area/almayer/squads/charlie)
+"uPa" = (
+/obj/structure/machinery/camera/autoname/almayer{
+	name = "ship-grade camera"
+	},
+/turf/open/floor/almayer{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/almayer/shipboard/brig/office)
 "uPr" = (
 /turf/open/floor/almayer{
 	dir = 5;
@@ -74809,7 +75035,7 @@
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "uWC" = (
 /obj/structure/sign/safety/maint{
 	pixel_x = -17
@@ -75154,7 +75380,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "veI" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 8
@@ -75165,6 +75391,22 @@
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/port_emb)
+"veY" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/clothing/head/headset{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/storage/bible{
+	desc = "As the legendary US Army chaplain once said, 'There are no Athiests in fancy offices'.";
+	name = "Holy Bible";
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "vfg" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
@@ -76321,7 +76563,7 @@
 /turf/open/floor/almayer{
 	icon_state = "redfull"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "vyg" = (
 /obj/structure/surface/table/almayer,
 /obj/structure/machinery/computer/secure_data,
@@ -77621,7 +77863,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "vVd" = (
 /obj/structure/pipes/standard/manifold/hidden/supply{
 	dir = 4
@@ -78130,7 +78372,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "wdF" = (
 /turf/open/floor/almayer{
 	allow_construction = 0
@@ -79231,6 +79473,16 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/upper/u_a_s)
+"wyn" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/structure/machinery/status_display{
+	pixel_y = -29
+	},
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "wyq" = (
 /obj/structure/stairs/perspective{
 	dir = 8;
@@ -79419,6 +79671,9 @@
 	icon_state = "plate"
 	},
 /area/almayer/maint/hull/lower/l_a_s)
+"wDn" = (
+/turf/closed/wall/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "wDs" = (
 /obj/structure/machinery/seed_extractor,
 /obj/structure/sign/safety/terminal{
@@ -79487,6 +79742,12 @@
 	icon_state = "rasputin3"
 	},
 /area/almayer/powered/agent)
+"wEy" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 4
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/office)
 "wEI" = (
 /obj/structure/surface/table/reinforced/black,
 /obj/item/tool/pen,
@@ -79886,7 +80147,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "wNy" = (
 /obj/structure/machinery/door/firedoor/border_only/almayer,
 /turf/open/floor/almayer{
@@ -79906,6 +80167,11 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/engineering/upper_engineering/starboard)
+"wOy" = (
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/office)
 "wOK" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -80003,7 +80269,7 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "wQv" = (
 /obj/structure/machinery/light{
 	dir = 8
@@ -80033,7 +80299,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "wRm" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -80305,7 +80571,7 @@
 	dir = 5
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "wUX" = (
 /obj/structure/surface/rack,
 /obj/item/reagent_container/food/snacks/sliceable/cheesewheel/mature{
@@ -80871,7 +81137,13 @@
 "xer" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /turf/open/floor/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
+"xez" = (
+/obj/structure/closet/secure_closet/military_police,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "xeO" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -81111,7 +81383,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xhM" = (
 /obj/structure/machinery/door/airlock/almayer/security/glass/reinforced{
 	dir = 1;
@@ -81130,7 +81402,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xhW" = (
 /obj/structure/bed/chair/comfy/ares{
 	dir = 1
@@ -81244,7 +81516,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xjK" = (
 /obj/structure/sign/safety/hazard{
 	pixel_y = 32
@@ -81291,6 +81563,22 @@
 	icon_state = "cargo_arrow"
 	},
 /area/almayer/squads/delta)
+"xkH" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "General Listening Channel"
+	},
+/obj/item/ashtray/bronze{
+	pixel_y = -12
+	},
+/obj/item/trash/cigbutt/cigarbutt{
+	pixel_x = 6
+	},
+/turf/open/floor/almayer{
+	icon_state = "bluefull"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "xkP" = (
 /obj/structure/pipes/standard/simple/hidden/supply{
 	dir = 4
@@ -81397,6 +81685,12 @@
 	icon_state = "cargo"
 	},
 /area/almayer/medical/lower_medical_medbay)
+"xmU" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 6
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "xnc" = (
 /turf/open/floor/almayer{
 	dir = 4;
@@ -81665,6 +81959,10 @@
 /obj/structure/toilet{
 	pixel_y = 13
 	},
+/obj/structure/machinery/camera/autoname/almayer{
+	dir = 8;
+	name = "ship-grade camera"
+	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
@@ -81685,7 +81983,7 @@
 /area/almayer/shipboard/brig/evidence_storage)
 "xsc" = (
 /turf/closed/wall/almayer,
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xsd" = (
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -82149,7 +82447,7 @@
 	dir = 1;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xAB" = (
 /obj/structure/surface/table/almayer,
 /obj/item/paper_bin/uscm,
@@ -82346,8 +82644,9 @@
 /obj/structure/machinery/door/firedoor/border_only/almayer{
 	dir = 2
 	},
-/obj/structure/machinery/door/airlock/multi_tile/almayer/marine/shared{
-	dir = 2
+/obj/structure/machinery/door/airlock/almayer/marine{
+	dir = 2;
+	name = "Squad Preparations"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
@@ -82428,7 +82727,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "xFw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -82540,7 +82839,13 @@
 /turf/open/floor/almayer{
 	icon_state = "red"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
+"xHl" = (
+/obj/structure/pipes/standard/simple/hidden/supply{
+	dir = 10
+	},
+/turf/open/floor/almayer,
+/area/almayer/shipboard/brig/mp_bunks)
 "xHG" = (
 /obj/structure/machinery/door/airlock/almayer/secure/reinforced{
 	dir = 2;
@@ -82827,6 +83132,22 @@
 	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
+"xMw" = (
+/obj/structure/surface/table/reinforced/almayer_B,
+/obj/item/clothing/head/headset{
+	pixel_y = -1;
+	pixel_x = 8
+	},
+/obj/item/clothing/head/helmet/marine/pilottex{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/item/clothing/mask/rebreather/scarf,
+/obj/item/storage/fancy/cigar/tarbacktube,
+/turf/open/floor/almayer{
+	icon_state = "plate"
+	},
+/area/almayer/shipboard/brig/mp_bunks)
 "xMy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/pipes/standard/simple/hidden/supply{
@@ -82863,7 +83184,7 @@
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"
 	},
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "xML" = (
 /obj/structure/machinery/computer/cameras/wooden_tv/prop{
 	pixel_x = -4;
@@ -83033,7 +83354,7 @@
 	icon_state = "W"
 	},
 /turf/open/floor/almayer,
-/area/almayer/living/pilotbunks)
+/area/almayer/shipboard/brig/mp_bunks)
 "xQm" = (
 /turf/open/floor/almayer/research/containment/floor2{
 	dir = 1
@@ -83585,7 +83906,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ybf" = (
 /obj/structure/machinery/cm_vending/sorted/medical/wall_med{
 	pixel_y = 25
@@ -84137,7 +84458,7 @@
 /turf/open/floor/almayer{
 	icon_state = "plate"
 	},
-/area/almayer/shipboard/brig/perma)
+/area/almayer/shipboard/brig/office)
 "ylc" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
@@ -92189,8 +92510,8 @@ wIC
 hzx
 wIC
 wIC
-naB
-naB
+clB
+clB
 bIi
 aWm
 kPo
@@ -92389,10 +92710,10 @@ wIC
 cNY
 xhU
 sip
-uQm
+wEy
 ntm
 hND
-fgl
+wOy
 hND
 aWm
 wMT
@@ -92583,18 +92904,18 @@ rvu
 tng
 iXS
 wzx
-naB
+clB
 paq
 uoY
 vUL
 vez
 xsc
 swo
-qPD
-qPD
-uQm
+flJ
+flJ
+wEy
 bua
-naB
+clB
 xkd
 xkd
 xkd
@@ -92786,16 +93107,16 @@ dPY
 rTV
 rvu
 ykl
-naB
+clB
 qfR
 xhU
 xhU
 apj
 xsc
 wNi
-qPD
-qPD
-uQm
+flJ
+flJ
+wEy
 eiO
 xFs
 xkd
@@ -92982,14 +93303,14 @@ iUq
 iUq
 rtT
 rvu
-naB
-naB
-naB
-naB
-naB
+clB
+clB
+clB
+clB
+clB
 qmC
-naB
-naB
+clB
+clB
 ouV
 bTw
 xer
@@ -92999,7 +93320,7 @@ tGg
 xer
 xer
 iqn
-qPD
+flJ
 tmy
 xkd
 rUB
@@ -93185,21 +93506,21 @@ iUq
 ext
 rtT
 mwI
-naB
+clB
 rBV
 oPk
 mqo
-naB
-qPD
+clB
+flJ
 rag
 qqN
 lzx
-uQm
+wEy
 bua
-ekg
+gNV
 oZX
 qre
-qPD
+flJ
 eOR
 aJz
 aWR
@@ -93388,15 +93709,15 @@ iUq
 oCL
 rvu
 fuB
-naB
-wNi
-pHp
-pHp
+clB
+uPa
+fXc
+fXc
 ckS
-qPD
+flJ
 bua
-ekg
-ekg
+gNV
+gNV
 tJy
 fnC
 tpn
@@ -93590,12 +93911,12 @@ aag
 iUq
 rvu
 rtT
-naB
-naB
+clB
+clB
 sFC
 sFC
 sFC
-naB
+clB
 pcQ
 xHe
 uwo
@@ -93793,12 +94114,12 @@ aag
 hwx
 rvu
 rtT
-naB
+clB
 ykP
 xAj
 xhE
 xhE
-naB
+clB
 hKq
 cdk
 soD
@@ -93996,17 +94317,17 @@ aag
 hwx
 rtT
 rvu
-naB
+clB
 ykP
 xjG
-elq
-ekg
+lqX
+gNV
 rmv
-qPD
-uQm
+flJ
+wEy
 bua
-gMf
-ekg
+cRX
+gNV
 ciF
 tpn
 vrM
@@ -94199,14 +94520,14 @@ aag
 hwx
 pGq
 rvu
-naB
-naB
-naB
-naB
-naB
-naB
+clB
+clB
+clB
+clB
+clB
+clB
 hZU
-uQm
+wEy
 fkn
 gaJ
 gaJ
@@ -94402,14 +94723,14 @@ aag
 iUq
 mwI
 kyo
-naB
+clB
 tJp
 ybb
 tHB
 aEk
 nSM
 wNi
-uQm
+wEy
 pYF
 gaJ
 wVV
@@ -94605,14 +94926,14 @@ aag
 iUq
 vjx
 rtT
-naB
+clB
 sQS
 mXU
 grl
 egR
 xhU
 lzx
-uQm
+wEy
 kkk
 fso
 bRH
@@ -94808,14 +95129,14 @@ aag
 hwx
 bdi
 rtT
-naB
+clB
 ikM
 pzc
 cNe
-qPD
-qPD
-qPD
-uQm
+flJ
+flJ
+flJ
+wEy
 kkk
 qvf
 bRH
@@ -95011,14 +95332,14 @@ aag
 hwx
 iXk
 rvu
-naB
+clB
 uwo
 buX
-uQm
-qPD
-qPD
-qPD
-uQm
+wEy
+flJ
+flJ
+flJ
+wEy
 pWG
 gaJ
 eyg
@@ -95214,7 +95535,7 @@ aag
 hwx
 rtT
 rvu
-naB
+clB
 jCa
 cFO
 lNs
@@ -95423,8 +95744,8 @@ bVC
 lrq
 lrq
 lut
-qPD
-qPD
+flJ
+flJ
 enz
 swn
 vOd
@@ -95626,8 +95947,8 @@ uqo
 wVw
 cqn
 gTx
-qPD
-qPD
+flJ
+flJ
 igt
 swn
 daj
@@ -95829,8 +96150,8 @@ uqo
 sYB
 cqn
 wNi
-qPD
-qPD
+flJ
+flJ
 cWs
 swn
 dcP
@@ -96033,7 +96354,7 @@ ktn
 cqn
 pkK
 mdS
-qPD
+flJ
 jVr
 swn
 dfO
@@ -106991,12 +107312,12 @@ awW
 awW
 hhA
 bLb
-unT
-kng
-fDV
-aiX
+hmO
+mNN
+veY
+wDn
 tAL
-avU
+qSJ
 avU
 awY
 awz
@@ -107194,10 +107515,10 @@ add
 add
 bQF
 eRu
-nwL
-amd
-lay
-aiX
+kzW
+lvD
+wyn
+wDn
 awY
 avU
 avU
@@ -107397,10 +107718,10 @@ aeZ
 aka
 aoI
 eRu
-fdE
-amd
-fdE
-aiX
+ilQ
+lvD
+ilQ
+wDn
 cJu
 avU
 avU
@@ -107600,17 +107921,17 @@ afr
 akc
 buc
 bLb
-hlU
-pcG
+eie
+koo
 nnc
-qnD
+eND
 lyi
 xQg
 iuu
 wQJ
 apo
 auZ
-aiX
+wDn
 bLb
 asl
 bqv
@@ -107803,15 +108124,15 @@ add
 add
 gqP
 bLb
-aiX
-aiX
-aiX
-aiX
+wDn
+wDn
+wDn
+wDn
 oqw
-dfW
+xmU
 osT
 ayv
-amd
+lvD
 sYI
 ana
 bLb
@@ -108006,15 +108327,15 @@ add
 add
 vmN
 bLb
-dUE
-kng
+xez
+mNN
 qOU
-alw
+eND
 vxW
-dXY
-rtY
+cuW
+xkH
 fJy
-amd
+lvD
 sYI
 ana
 bLb
@@ -108209,15 +108530,15 @@ aeZ
 aka
 aoI
 gks
-nwL
-amd
-nPx
-aiX
+kzW
+lvD
+pWT
+wDn
 awq
-dXY
+cuW
 ePk
 ePk
-amd
+lvD
 apq
 jHl
 tCi
@@ -108412,15 +108733,15 @@ afr
 akc
 xVI
 bLb
-aku
-pcG
-qnl
-aiX
+xMw
+koo
+skp
+wDn
 apt
 pQd
-pWN
-pWN
-pWN
+tgv
+tgv
+tgv
 nBE
 pOD
 bZa
@@ -108615,14 +108936,14 @@ add
 add
 vmN
 bLb
-aiX
-aiX
-aiX
-aiX
+wDn
+wDn
+wDn
+wDn
 awq
-sCI
+xHl
 wUR
-amd
+lvD
 lew
 awA
 mJL
@@ -108818,14 +109139,14 @@ add
 add
 add
 bLb
-dUE
-kng
+xez
+mNN
 tlI
-alw
+eND
 vxW
 dGr
 evg
-amd
+lvD
 lew
 szO
 bLb
@@ -109021,14 +109342,14 @@ aeZ
 aka
 oMM
 aRq
-nwL
-amd
-nPx
-aiX
-pQV
-uOJ
-pqc
-amd
+kzW
+lvD
+pWT
+wDn
+hbs
+nBn
+ccL
+lvD
 aWq
 szO
 bLb
@@ -109224,18 +109545,18 @@ afr
 akc
 buc
 bLb
-akv
-pcG
-qnl
-aiX
-aiX
-aiX
-aiX
+qZP
+koo
+skp
+wDn
+wDn
+wDn
+wDn
 xMB
 bLb
 bLb
 bLb
-aiX
+wDn
 ukh
 qgN
 nxK
@@ -109434,7 +109755,7 @@ aau
 uVX
 ase
 aqz
-amd
+lvD
 bLb
 eaJ
 hUg
@@ -109832,7 +110153,7 @@ acW
 awW
 awW
 ohB
-aiX
+wDn
 vwV
 vwV
 vwV
@@ -125175,7 +125496,7 @@ bmD
 osV
 bmD
 bqg
-bmD
+dSO
 mYv
 doP
 jac
@@ -127402,7 +127723,7 @@ bCA
 bCA
 cvb
 bmC
-nwG
+sWF
 lDL
 nwG
 lMw


### PR DESCRIPTION
# Что изменилось?

Фиксы:
- Шлюзы, ведущие в префы в задней части корабля, теперь не переходят на коридор. (Карбоны не будут спотыкаться об воздух проходя рядом со шлюзом)
- Теперь МП Bunks официально имеет зону Brig MP's Bunks, за место Pilot's Bunks и своё АПЦ.
Добавлено:
- Новая зона Brig Office для покрытия офиса брига, за место зоны Brig Perma + АПЦ.
- В МП Bunks за место Pilot Closet были добавлены MP Closet.
- 3 камеры прямо в карго и по одной в каждую камеру пермабрига

# Почему это нужно замерджить??

По поводу фиксов:
1. Теперь новички на пилотах не будут путаться с комнатами.
2. Ксеносы и морпехи, не имеющие доступ к префам, не будут спотыкаться об воздух, проходя рядом со шлюзом, около генераторов.
По поводу добавленного:
1. Новая зона и меньше путаницы по камерам.
2. Заменить ящики пилотов на ящики МПшников банально логично, ведь это комната отдыха для МП.
3. Камеры в карго для удобства просмотра со стороны командования и МП работоспособность карго. Камеры в клетках пермабрига для удобства МПшников в слежке за изолированными пермовцами.


https://github.com/RU-CMSS13/RU-CMSS13/assets/171371914/8c7c3284-e13a-4b45-857d-b24337d765ae



</details>


# Чейджлог

:cl:
maptweak: Фиксы и новая зона
add: Новая зона Brig Office
add: 3 камеры в Cargo и 2 в Perma Cells
fix: Ящики МП вместо пилотов в MP's Bunks
fix: Аирлоки больше не стоят в воздухе
code: Новая зона Brig Office
/:cl:
