### PR TITLE
Medical pamphlet skill issue

### DIFF
--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -50,6 +50,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 		list("Night Vision Optic", 25, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
 
+//RUCM START
+		list("PAMPHLETS", 0, null, null, null),
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
+
 		list("RADIO KEYS", 0, null, null, null),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
 	))

--- a/code/game/machinery/vending/vendor_types/requisitions.dm
+++ b/code/game/machinery/vending/vendor_types/requisitions.dm
@@ -136,6 +136,9 @@
 		list("Sentry Gun Network Laptop", 4, /obj/item/device/sentry_computer, VENDOR_ITEM_REGULAR),
 		list("JTAC Pamphlet", floor(scale * 1), /obj/item/pamphlet/skill/jtac, VENDOR_ITEM_REGULAR),
 		list("Engineering Pamphlet", floor(scale * 1), /obj/item/pamphlet/skill/engineer, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("Medical Pamphlet", floor(scale * 1), /obj/item/pamphlet/skill/medical, VENDOR_ITEM_REGULAR),
+//RUCM END
 		list("Powerloader Certification", 0.75, /obj/item/pamphlet/skill/powerloader, VENDOR_ITEM_REGULAR),
 		list("Spare PDT/L Battle Buddy Kit", floor(scale * 4), /obj/item/storage/box/pdt_kit, VENDOR_ITEM_REGULAR),
 		list("W-Y brand rechargeable mini-battery", floor(scale * 3), /obj/item/cell/crap, VENDOR_ITEM_REGULAR)

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_engineer.dm
@@ -88,6 +88,9 @@ GLOBAL_LIST_INIT(cm_vending_gear_engi, list(
 
 		list("PAMPHLETS", 0, null, null, null),
 		list("JTAC Pamphlet", 15, /obj/item/pamphlet/skill/jtac, null, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
 
 		list("RADIO KEYS", 0, null, null, null),
 		list("Intel Radio Encryption Key", 3, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_rifleman.dm
@@ -120,6 +120,9 @@ GLOBAL_LIST_INIT(cm_vending_clothing_marine, list(
 		list("PAMPHLETS", 0, null, null, null),
 		list("JTAC Pamphlet", 15, /obj/item/pamphlet/skill/jtac, null, VENDOR_ITEM_REGULAR),
 		list("Engineering Pamphlet", 15, /obj/item/pamphlet/skill/engineer, null, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
 
 		list("RADIO KEYS", 0, null, null, null),
 		list("Engineering Radio Encryption Key", 5, /obj/item/device/encryptionkey/engi, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_smartgunner.dm
@@ -43,6 +43,9 @@ GLOBAL_LIST_INIT(cm_vending_gear_smartgun, list(
 		list("Roller Bed", 5, /obj/item/roller, null, VENDOR_ITEM_REGULAR),
 		list("Fulton Device Stack", 5, /obj/item/stack/fulton, null, VENDOR_ITEM_REGULAR),
 		list("Smartgun DV9 Battery", 15, /obj/item/smartgun_battery, null, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
 
 		list("BINOCULARS", 0, null, null, null),
 		list("Binoculars", 5, /obj/item/device/binoculars, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_specialist.dm
@@ -140,6 +140,9 @@ GLOBAL_LIST_INIT(cm_vending_clothing_specialist, list(
 		list("PAMPHLETS", 0, null, null, null),
 		list("JTAC Pamphlet", 15, /obj/item/pamphlet/skill/jtac, null, VENDOR_ITEM_REGULAR),
 		list("Engineering Pamphlet", 15, /obj/item/pamphlet/skill/engineer, null, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
 
 		list("RADIO KEYS", 0, null, null, null),
 		list("Engineering Radio Encryption Key", 5, /obj/item/device/encryptionkey/engi, null, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
+++ b/code/game/machinery/vending/vendor_types/squad_prep/squad_tl.dm
@@ -68,6 +68,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_tl, list(
 		list("Medical Helmet Optic", 15, /obj/item/device/helmet_visor/medical, null, VENDOR_ITEM_REGULAR),
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 
+//RUCM START
+		list("PAMPHLETS", 0, null, null, null),
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
+
 		list("RADIO KEYS", 0, null, null, null),
 		list("Engineering Radio Encryption Key", 5, /obj/item/device/encryptionkey/engi, null, VENDOR_ITEM_REGULAR),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),


### PR DESCRIPTION
# About the pull request

Даёт возможность получить морпеху/спеку/ио/РТО/инженеру 1-ый уровень медицины для быстрого использования медицины в подсумке который ему предлагается

# Explain why it's good for the game

Вместо добавления EZ инжекторов в каждый такой подсумок, я даю возможность морпехам за 15 поинтов получить быстрое использование инжекторов, так ещё дополнительно они могут взять большой подсумок инжекторов в карго.

# Testing Photographs and Procedure

<details>
... Ну а что ты думал тут увидеть?
</details>


# Changelog

:cl:
add: Медицинские инструкции появились во всех вендорах морпехов (Карго тоже)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
