### PR TITLE
Full update RU_Almayer for upstream

### DIFF
--- a/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
+++ b/maps/map_files/USS_Almayer_RU/USS_Almayer_RU.dmm
@@ -17733,8 +17733,8 @@
 	},
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Mech Bay";
-	req_access = list(33);
-	req_one_access = list()
+	req_one_access = list(40;1);
+	req_one_access_txt = "40;1"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -39659,9 +39659,9 @@
 /obj/structure/pipes/standard/simple/hidden/supply,
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Mech Ops's Room";
-	req_access = list(33);
-	req_one_access = list();
-	dir = 2
+	req_one_access = list(40;1);
+	dir = 2;
+	req_one_access_txt = "40;1"
 	},
 /turf/open/floor/almayer{
 	icon_state = "plate"
@@ -40802,8 +40802,8 @@
 "ijp" = (
 /obj/structure/machinery/door/airlock/almayer/generic{
 	name = "\improper Mech Ops's Room";
-	req_access = list(33);
-	req_one_access = list()
+	req_one_access = list(40;1);
+	req_one_access_txt = "40;1"
 	},
 /turf/open/floor/almayer{
 	icon_state = "test_floor4"


### PR DESCRIPTION
#About the pull request
Произошли следующие изменения на карте русского Алмаера:

1. Офис представителя компании W-Y:
  1.1 Обновлены створки. Отделены створки дверей от створок окон.
  1.2 Добавлены кнопки контроля новых створок + кнопка, позволяющая разблокировать под
        эвакуации КЛа.
  1.3 Добавлена новая одежда.
  1.4 Добавлен именной сейф для КЛа.
  1.5 Добавлен супермегакрасивый фотокопир W-Y, вместо обычного.
  1.6 Добавлены подслушивающие устройства. Жучки.
2. Добавлен анализатор биомассы для ученых.
3. Добавлены питающие пады для наномедов.
4. Добавлены колокольчики в карго, медбей, офис КЛа.
5. Добавлены створки на запасное хранилище инженерного отдела + обновление стен хранилища до огнеустойчивых. Кнопка открытия створок в кабинете СЕ.
6. Добавлены специальные вендоры для выдачи боевого снаряжение SO в оружейную КИКа.
7. Добавлены специальные вендоры для MT.
8. Добавлены подслушивающие устройства MP в кабинет вардена.
9. Добавлена печать "ОДОБРЕНО" в офис КМа.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Пу-пу-пу

</details>


# Changelog

:cl:
maptweak: Обновление офиса CL
maptweak: Добавление питающих падов для наномедов на Алмаер.
maptweak: Добавление учёным анализатор биомассы.
maptweak: Добавление вендоров MT и Armory SO.
maptweak: Добавление колокольчиков. Добавление печати "ОДОБРЕНО" в офис КМа.
maptweak: Добавление створок на запасное хранилище в инженерном отделе.
maptweak: Добавление подслушивающих устройств MP и W-Y.
/:cl: