### PR TITLE
Yautja renegades update, jump from Danilcus

### DIFF
--- a/code/modules/cm_preds/yaut_hudprocs.dm
+++ b/code/modules/cm_preds/yaut_hudprocs.dm
@@ -86,7 +86,12 @@
 	// We only target living humans and xenos
 	var/list/target_list = list()
 	for(var/mob/living/prey in view(7, usr.client))
+/*
 		if((ishuman_strict(prey) || isxeno(prey)) && prey.stat != DEAD)
+*/
+//RUCM START
+		if((ishuman_strict(prey) || isxeno(prey) || isyautja(prey)) && prey.stat != DEAD) // Renegades hunt my beloved
+//RUCM END
 			target_list += prey
 
 	var/mob/living/carbon/M = tgui_input_list(usr, "Target", "Choose a prey.", target_list)
@@ -100,6 +105,9 @@
 	M.hunter_data.hunted = TRUE
 	M.hud_set_hunter()
 
+//RUCM START
+	to_chat(M, SPAN_YAUTJABOLD("YOU CHOSEN FOR HUNT, you have 1 minute to prepare"))
+//RUCM END
 	// Notify the pred
 	to_chat(src, SPAN_YAUTJABOLD("You have chosen [hunter_data.prey] as your next prey."))
 

--- a/code/modules/mob/living/carbon/human/species/yautja/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/yautja/_species.dm
@@ -215,6 +215,9 @@
 	give_action(hunter, /datum/action/yautja_emote_panel)
 	give_action(hunter, /datum/action/predator_action/mark_for_hunt)
 	give_action(hunter, /datum/action/predator_action/mark_panel)
+//RUCM START
+	give_action(hunter, /datum/action/human_action/yautja_jump)
+//RUCM END
 	return ..()
 
 /datum/species/yautja/get_hairstyle(style)

--- a/core_ru/code/includes.dm
+++ b/core_ru/code/includes.dm
@@ -91,6 +91,7 @@
 #include "modules\cm_tech\techs\xeno\tier3\rev_jelly.dm"
 #include "modules\cm_tech\techs\xeno\tier4\health_up.dm"
 #include "modules\cm_tech\trees\xeno.dm"
+#include "modules\cm_preds\yaut_actions.dm"
 #include "modules\gear_presets\usmc.dm"
 #include "modules\gear_presets\uscm_ship.dm"
 #include "modules\mob\mod_defines.dm"

--- a/core_ru/code/modules/cm_preds/yaut_actions.dm
+++ b/core_ru/code/modules/cm_preds/yaut_actions.dm
@@ -1,0 +1,105 @@
+/datum/action/human_action/yautja_jump
+	///How quick you will fly
+	var/speed = SPEED_AVERAGE
+	///How many tiles you can leap to at once.
+	var/max_distance = 6
+
+/datum/action/human_action/yautja_jump/New(mob/living/user, obj/item/holder)
+	..()
+	name = "Long Jump"
+	button.name = name
+	button.overlays.Cut()
+	var/image/IMG = image('icons/mob/hud/actions.dmi', button, "prepare_position")
+	button.overlays += IMG
+
+/datum/action/human_action/yautja_jump/can_use_action()
+	var/mob/living/carbon/human/H = owner
+	if(!H.is_mob_incapacitated() && !H.body_position == LYING_DOWN)
+		return TRUE
+
+/datum/action/human_action/yautja_jump/action_activate()
+	var/mob/living/carbon/human/H = owner
+	if(H.selected_ability == src)
+		to_chat(H, "You will no longer use [name] with \
+			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		button.icon_state = "template"
+		H.selected_ability = null
+	else
+		to_chat(H, "You will now use [name] with \
+			[H.client && H.client.prefs && H.client.prefs.toggle_prefs & TOGGLE_MIDDLE_MOUSE_CLICK ? "middle-click" : "shift-click"].")
+		if(H.selected_ability)
+			H.selected_ability.button.icon_state = "template"
+			H.selected_ability = null
+		button.icon_state = "template_on"
+		H.selected_ability = src
+
+/datum/action/human_action/yautja_jump/proc/use_ability(atom/A)
+	var/mob/living/carbon/human/H = owner
+	H.jump(A, speed, max_distance)
+	update_button_icon()
+
+/mob/living/carbon/human/var/can_jump = TRUE
+/mob/living/carbon/human/var/jump_cooldown = 2 SECONDS
+
+/mob/living/carbon/human/proc/jump(atom/A, speed, max_distance)
+	if (!A.z)
+		return FALSE
+
+	if (is_mob_incapacitated() || body_position == LYING_DOWN)
+		to_chat(src, SPAN_WARNING("You're a bit too incapacitated for that."))
+		return FALSE
+
+	if (!can_jump)
+		to_chat(src, SPAN_WARNING("You cannot jump yet!"))
+		return FALSE
+
+	var/turf/t_turf = get_turf(A)
+	if (t_turf == get_turf(src))
+		return FALSE
+
+	can_jump = FALSE
+
+	var/t_dist = min(get_dist(src, t_turf), max_distance)
+	var/delay = 0.05 SECONDS * t_dist - 0.05 SECONDS
+
+	to_chat(src, SPAN_BOLDNOTICE("You prepare to jump"))
+	if (!do_after(src, delay, INTERRUPT_ALL|BEHAVIOR_IMMOBILE, BUSY_ICON_GENERIC))
+		can_jump = TRUE
+		return FALSE
+
+	playsound(src, 'sound/effects/alien_tail_swipe2.ogg', 25, TRUE)
+	jump_animation(speed, t_turf, max_distance)
+
+	//has sleep
+	RegisterSignal(src, COMSIG_CLIENT_MOB_MOVE, PROC_REF(disable_flying_movement))
+	throw_atom(t_turf, max_distance, speed, launch_type = HIGH_LAUNCH)
+	addtimer(CALLBACK(src, PROC_REF(end_jump_cooldown)), jump_cooldown)
+	UnregisterSignal(src, COMSIG_CLIENT_MOB_MOVE)
+
+/mob/living/carbon/human/proc/jump_animation(speed, turf/t_turf, max_distance)
+	set waitfor = FALSE
+
+	var/old_alpha = alpha
+	var/new_alpha = 160
+
+	if (alpha < 160)
+		new_alpha = old_alpha
+
+	var/anim_s = 0.95
+	var/t_dist = min(get_dist(src, t_turf), max_distance)
+	var/travel_time = (10 / speed - 0.6) * t_dist / 2 * anim_s
+	var/pixel_height = pixel_y + 3 * t_dist - 3
+
+	animate(src, alpha = new_alpha, pixel_y = pixel_y+pixel_height, time = travel_time, easing = SINE_EASING|EASE_OUT)
+
+	sleep(travel_time)
+
+	animate(src, alpha = old_alpha, pixel_y = initial(src.pixel_y), time = travel_time, easing = SINE_EASING)
+
+/mob/living/carbon/human/proc/disable_flying_movement()
+	SIGNAL_HANDLER
+	return COMPONENT_OVERRIDE_MOVE
+
+/mob/living/carbon/human/proc/end_jump_cooldown()
+	can_jump = TRUE
+	to_chat(src, SPAN_BOLDNOTICE("You are ready to jump again!"))


### PR DESCRIPTION
# About the pull request

Хищкутены могут помечать на охоту других хищкутенов. При объявлении охоты, жертве даётся сообщение об охоте. Я взял прыжок с ПРа #116 от Данилкуса, он всем понравился очень!!!

# Explain why it's good for the game

Ренегаты могут охотится на яутж, жертвы должны знать что за ними охотятся

# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog


:cl:
add: Прыг скок для яутжи
qol: Объявление охоты даёт сообщение
qol: Хищники могут поставить метку охоты на хищников
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
