### PR TITLE
More weapon for Intel

### DIFF
--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -59,6 +59,11 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 		list("Night Vision Optic", 25, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
 
+//RUCM START
+		list("PAMPHLETS", 0, null, null, null),
+		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
+//RUCM END
+
 		list("RADIO KEYS", 0, null, null, null),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
 

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -15,6 +15,9 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("M39 Extended Magazine (10x20mm)", 10, /obj/item/ammo_magazine/smg/m39/extended , null, VENDOR_ITEM_REGULAR),
 		list("M41A AP Magazine (10x24mm)", 10, /obj/item/ammo_magazine/rifle/ap , null, VENDOR_ITEM_REGULAR),
 		list("M41A Extended Magazine (10x24mm)", 10, /obj/item/ammo_magazine/rifle/extended , null, VENDOR_ITEM_REGULAR),
+//RUCM START
+		list("M41A MK1 AP Magazine(10x24mm)", 10, /obj/item/ammo_magazine/rifle/m41aMK1/ap , null, VENDOR_ITEM_REGULAR),
+//RUCM END
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),
 		list("M44 Heavy Speed Loader (.44)", 10, /obj/item/ammo_magazine/revolver/heavy, null, VENDOR_ITEM_REGULAR),
@@ -23,6 +26,12 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("M4A3 AP Magazine", 5, /obj/item/ammo_magazine/pistol/ap, null, VENDOR_ITEM_REGULAR),
 		list("VP78 Magazine", 5, /obj/item/ammo_magazine/pistol/vp78, null, VENDOR_ITEM_REGULAR),
 		list("SU-6 Smartpistol Magazine (.45)", 10, /obj/item/ammo_magazine/pistol/smart, null, VENDOR_ITEM_REGULAR),
+
+//RUCM START
+		list("SPECIAL WEAPONS", 0, null, null, null),
+		list("MK1 kit (No mods)", 15, /obj/item/storage/box/guncase/m41aMK1, null, VENDOR_ITEM_REGULAR),
+		list("MOU-53 Shotgun", 15, /obj/item/storage/box/guncase/mou53, null, VENDOR_ITEM_REGULAR),
+//RUCM END
 
 		list("RESTRICTED FIREARMS", 0, null, null, null),
 		list("VP78 Pistol", 15, /obj/item/storage/box/guncase/vp78, null, VENDOR_ITEM_REGULAR),
@@ -49,11 +58,6 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("Medical Helmet Optic", 5, /obj/item/device/helmet_visor/medical, null, VENDOR_ITEM_REGULAR),
 		list("Welding Visor", 5, /obj/item/device/helmet_visor/welding_visor, null, VENDOR_ITEM_REGULAR),
 		list("Night Vision Optic", 25, /obj/item/device/helmet_visor/night_vision, null, VENDOR_ITEM_RECOMMENDED),
-
-//RUCM START
-		list("PAMPHLETS", 0, null, null, null),
-		list("Medical Pamphlet", 15, /obj/item/pamphlet/skill/medical, null, VENDOR_ITEM_RECOMMENDED),
-//RUCM END
 
 		list("RADIO KEYS", 0, null, null, null),
 		list("Intel Radio Encryption Key", 5, /obj/item/device/encryptionkey/intel, null, VENDOR_ITEM_REGULAR),
@@ -169,6 +173,7 @@ GLOBAL_LIST_INIT(cm_vending_guns_intelligence_officer, list(
 		list("M39 Submachine Gun", 4, /obj/item/weapon/gun/smg/m39, VENDOR_ITEM_REGULAR),
 		list("M37A2 Pump Shotgun", 4, /obj/item/weapon/gun/shotgun/pump, VENDOR_ITEM_REGULAR),
 		list("M41A Pulse Rifle MK2", 4, /obj/item/weapon/gun/rifle/m41a, VENDOR_ITEM_REGULAR),
+
 
 		list("PRIMARY AMMUNITION", -1, null, null),
 		list("Box of Buckshot Shells (12g)", 12, /obj/item/ammo_magazine/shotgun/buckshot, VENDOR_ITEM_REGULAR),

--- a/code/game/machinery/vending/vendor_types/intelligence_officer.dm
+++ b/code/game/machinery/vending/vendor_types/intelligence_officer.dm
@@ -17,6 +17,7 @@ GLOBAL_LIST_INIT(cm_vending_gear_intelligence_officer, list(
 		list("M41A Extended Magazine (10x24mm)", 10, /obj/item/ammo_magazine/rifle/extended , null, VENDOR_ITEM_REGULAR),
 //RUCM START
 		list("M41A MK1 AP Magazine(10x24mm)", 10, /obj/item/ammo_magazine/rifle/m41aMK1/ap , null, VENDOR_ITEM_REGULAR),
+		list("M41A MK1 Magazine(10x24mm)", 5, /obj/item/ammo_magazine/rifle/m41aMK1, null, VENDOR_ITEM_REGULAR),
 //RUCM END
 
 		list("SIDEARM AMMUNITION", 0, null, null, null),


### PR DESCRIPTION
# About the pull request

This Pr adds weapons for points to the IO vendor

# Explain why it's good for the game
Basically, it doesn't fundamentally change anything, it just adds the ability for an IO to purchase a weapon of their choice

# Testing Photographs and Procedure

Testing on Local server
# Changelog

:cl:
add: M41A MK1 to Gear Vendor for 15 points
add: Mou to Gear Vendor for 15 points
add: M41A MK 1 AP Magazine for 10 points
add: M41A MK Magazine for 5 points
/:cl:

