### PR TITLE
Mech fix

### DIFF
--- a/code/game/objects/structures/blocker.dm
+++ b/code/game/objects/structures/blocker.dm
@@ -139,7 +139,9 @@
 
 
 /obj/structure/blocker/forcefield/vehicles
+/* RUCM REMOVAL
 	types = list(/obj/vehicle/)
+*/
 
 
 /obj/structure/blocker/forcefield/vehicles/handle_vehicle_bump(obj/vehicle/multitile/multitile_vehicle)


### PR DESCRIPTION
# About the pull request

ПР убирает блокировку меха в передвижении

# Explain why it's good for the game

Так как любой мультитайл может проехать в пещеры, мех тоже должен мочь


# Testing Photographs and Procedure

Компилится


# Changelog
:cl:
fix: Mech can walk trough blockers
/:cl:
