### PR TITLE
APC zone and telephone fix

### DIFF
--- a/maps/interiors/apcru.dmm
+++ b/maps/interiors/apcru.dmm
@@ -103,7 +103,7 @@
 	pixel_x = 8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "an" = (
 /obj/structure/interior_wall/apc{
 	icon_state = "corner_inverse_R";
@@ -185,7 +185,7 @@
 	tag = "left"
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "az" = (
 /obj/effect/landmark/interior/spawn/interior_viewport{
 	pixel_x = -6;
@@ -197,7 +197,7 @@
 	pixel_y = -2
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aA" = (
 /obj/structure/interior_wall/apc{
 	icon_state = "front_wheel_L";
@@ -238,7 +238,7 @@
 	icon_state = "triagedecalbottomright"
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aF" = (
 /obj/effect/landmark/interior/spawn/interior_camera{
 	dir = 10;
@@ -246,7 +246,7 @@
 	pixel_y = 38
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aH" = (
 /obj/structure/bed/chair/vehicle{
 	pixel_x = 8
@@ -255,7 +255,7 @@
 	pixel_x = -8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aI" = (
 /obj/structure/bed/chair/vehicle{
 	pixel_x = -8
@@ -263,17 +263,21 @@
 /obj/structure/bed/chair/vehicle{
 	pixel_x = 8
 	},
-/obj/effect/landmark/interior/spawn/telephone{
-	pixel_x = 5;
-	pixel_y = 30
-	},
 /obj/structure/extinguisher_cabinet/lifeboat{
 	icon = 'icons/obj/vehicles/interiors/general.dmi';
 	pixel_x = -8;
 	pixel_y = 28
 	},
+/obj/structure/transmitter{
+	pixel_x = 5;
+	pixel_y = 30;
+	phone_id = "M888 Armored Personnel Carrier";
+	name = "APC Telephone";
+	icon = 'icons/obj/vehicles/interiors/general.dmi';
+	phone_category = "Vehicles"
+	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aJ" = (
 /obj/structure/vehicle_locker{
 	pixel_y = 28
@@ -282,7 +286,7 @@
 	dir = 4
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aK" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/recharger,
@@ -291,7 +295,7 @@
 	icon_state = "triagedecalbottom"
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aL" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -303,11 +307,11 @@
 	icon_state = "triagedecaltopright"
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aO" = (
 /obj/effect/landmark/interior/spawn/weapons_loader,
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aP" = (
 /obj/structure/surface/table/reinforced/prison{
 	pixel_y = -3
@@ -323,31 +327,31 @@
 	pixel_y = 4
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aQ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aS" = (
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aU" = (
 /obj/effect/landmark/interior/spawn/vehicle_driver_seat/armor{
 	dir = 4
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aV" = (
 /obj/structure/surface/table/reinforced/prison,
 /obj/structure/machinery/prop/almayer/CICmap,
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aW" = (
 /obj/structure/prop/vehicle/sensor_equipment,
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aX" = (
 /obj/effect/landmark/interior/spawn/vehicle_support_gunner_seat/second,
 /obj/structure/prop/vehicle/firing_port_weapon{
@@ -356,14 +360,14 @@
 	pixel_y = 2
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aY" = (
 /obj/structure/bed/chair/vehicle{
 	dir = 1;
 	pixel_x = 8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "aZ" = (
 /obj/structure/bed/chair/vehicle{
 	dir = 1;
@@ -379,7 +383,7 @@
 	pixel_y = 8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "ba" = (
 /obj/effect/landmark/interior/spawn/entrance{
 	alpha = 50;
@@ -388,7 +392,7 @@
 	tag = "right"
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "bc" = (
 /obj/structure/bed/chair/vehicle{
 	dir = 1;
@@ -399,7 +403,7 @@
 	pixel_x = -8
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 "bd" = (
 /obj/structure/interior_wall/apc{
 	alpha = 100;
@@ -428,7 +432,7 @@
 	pixel_y = 17
 	},
 /turf/open/shuttle/vehicle/apc,
-/area/interior/vehicle)
+/area/interior/vehicle/apc)
 
 (1,1,1) = {"
 aa


### PR DESCRIPTION
# About the pull request

БТР теперь имеет свою собственную зону, которая позволяет отображать на датчиках местность где находится танкист (Вместо Unknown теперь пишется APC interiror)

Так же телефон внутри БТРа теперь назван соответствующе.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>



</details>

![Снимок экрана 2025-03-14 190652](https://github.com/user-attachments/assets/87189020-14da-446a-bc2c-f14947548882)

![Снимок экрана 2025-03-14 190741](https://github.com/user-attachments/assets/6222b51e-f848-48bc-8202-425c894271b5)

![Снимок экрана 2025-03-14 190816](https://github.com/user-attachments/assets/8126ddf4-ade6-49e3-a4d5-7f177152eb7b)


# Changelog

:cl:
maptweak: APC zone and telephone fix
/:cl:
