### PR TITLE
Старт для балансировки стрейнов суслика.

### DIFF
--- a/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,4 +1,4 @@
 /datum/caste_datum/queen
 	speed = XENO_SPEED_TIER_1
 
-	available_strains = list(/datum/xeno_strain/royal_charger)
+//	available_strains = list(/datum/xeno_strain/royal_charger)


### PR DESCRIPTION
# About the pull request

Сейчас квина-крашер это просто сильно усиленная версия обычного крашера, без каких либо противостояний. Засчёт чего у нас есть ультимативный Т4 ксеноморф.
Так же из за обнаруженного бага стрейн будет временно отключён.

Обсуждения насчёт балансировки ниже приветствуются. На данный момент лично меня не устраивает стрейн королевы и равагера.

# Explain why it's good for the game

Вводить стрейны в баланс это хорошо.


# Testing Photographs and Procedure
Это пока лишь только комментирование


# Changelog

:cl:
balance: Try balance some crystal strains
/:cl:
