### PR TITLE
Mech double weapons fix

### DIFF
--- a/core_ru/code/modules/vehicles/walker.dm
+++ b/core_ru/code/modules/vehicles/walker.dm
@@ -434,14 +434,14 @@
 	else if(istype(held_item, /obj/item/walker_gun))
 		var/remaining_slots = list()
 		for(var/hardpoint_slot in list(WALKER_HARDPOIN_LEFT, WALKER_HARDPOIN_RIGHT))
-			if (module_map[WALKER_HARDPOIN_LEFT]?.type == held_item.type || module_map[WALKER_HARDPOIN_RIGHT]?.type == held_item.type)
-				to_chat(user, "You cannot install two of the same type of gun.")
-				return
 
 			if(module_map[hardpoint_slot])
 				continue
 			remaining_slots += hardpoint_slot
 		var/slot = tgui_alert(user, "On which hardpoint install gun.", "Hardpoint", remaining_slots + "Cancel")
+		if (module_map[WALKER_HARDPOIN_LEFT]?.type == held_item.type || module_map[WALKER_HARDPOIN_RIGHT]?.type == held_item.type)
+			to_chat(user, "You cannot install two of the same type of gun.")
+			return
 		if(slot && slot != "Cancel")
 			install_gun(held_item, user, slot)
 

--- a/core_ru/code/modules/vehicles/walker_vendor.dm
+++ b/core_ru/code/modules/vehicles/walker_vendor.dm
@@ -1,5 +1,5 @@
 GLOBAL_LIST_INIT(cm_vending_walker, list(
-	list("WEAPONS (choose 2)", 0, null, null, null),
+	list("WEAPONS, DO NOT PICK SIMILAR (choose 2)", 0, null, null, null),
 	list("M88 Mounted Automated Anti-Material rifle", 0, /obj/item/walker_gun/wm88, MECH_GUN, VENDOR_ITEM_REGULAR),
 	list("M56 Double-Barrel Mounted Smartgun", 0, /obj/item/walker_gun/smartgun, MECH_GUN, VENDOR_ITEM_REGULAR),
 	list("M32 Mounted Shotgun", 0,/obj/item/walker_gun/shotgun8g, MECH_GUN, VENDOR_ITEM_REGULAR),
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(cm_vending_walker, list(
 
 	unslashable = TRUE
 
-	vend_delay = 4 SECONDS
+	vend_delay = 1 SECONDS
 	vend_sound = 'sound/machines/medevac_extend.ogg'
 
 	vend_flags = VEND_CLUTTER_PROTECTION|VEND_CATEGORY_CHECK|VEND_TO_HAND|VEND_USE_VENDOR_FLAGS


### PR DESCRIPTION
# About the pull request

Мех теперь не может поставить второе одинаковое оружие багом. Добавлено предупреждение в вендор не брать одинаковое оружие.

# Changelog

:cl:
fix: Mech cant have two similar guns
/:cl:
