### PR TITLE
Tank tech fix

### DIFF
--- a/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
+++ b/code/game/machinery/vending/vendor_types/crew/vehicle_crew.dm
@@ -80,6 +80,7 @@
 
 	if(istype(VO, /obj/effect/vehicle_spawner/tank))
 		selected_vehicle = "TANK"
+		available_categories &= ~(VEHICLE_INTEGRAL_AVAILABLE) //мы и так пока спавнимся с башней, лишний флаг
 		marine_announcement("Tank is being sent up to reinforce this operation. Good luck")
 	else
 		selected_vehicle = "APC"
@@ -98,6 +99,10 @@
 	if(selected_vehicle == "TANK")
 		if(available_categories)
 			display_list = GLOB.cm_vending_vehicle_crew_tank
+//RUCM EDIT START
+		else
+			display_list = GLOB.cm_vending_vehicle_crew_tank_spare
+//RUCM EDIT ENDS
 
 	else if(selected_vehicle == "ARC")
 		display_list = GLOB.cm_vending_vehicle_crew_arc
@@ -130,7 +135,10 @@
 		var/prod_available = FALSE
 		var/p_cost = myprod[2]
 		var/avail_flag = myprod[4]
-		if(budget_points >= p_cost && (!avail_flag || available_categories & avail_flag))
+//RUCM EDIT START
+		//if(budget_points >= p_cost && (!avail_flag || available_categories & avail_flag))
+		if(available_points_to_display >= p_cost && (!avail_flag || available_categories & avail_flag))
+//RUCM EDIT ENDS
 			prod_available = TRUE
 		stock_values += list(prod_available)
 
@@ -149,7 +157,10 @@
 			to_chat(H, SPAN_WARNING("Not enough points."))
 			vend_fail()
 			return FALSE
-		budget_points -= L[2]
+// RUCM EDIT START
+		//budget_points -= L[2]
+		available_points_to_display -= L[2]
+//RUCM EDIT ENDS
 
 GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank, list(
 	list("STARTING KIT SELECTION:", 0, null, null, null),

--- a/core_ru/code/game/jobs/job/command/auxiliary/tankcrew.dm
+++ b/core_ru/code/game/jobs/job/command/auxiliary/tankcrew.dm
@@ -9,3 +9,37 @@
 		return 2
 
 	return 0
+
+GLOBAL_LIST_INIT(cm_vending_vehicle_crew_tank_spare, list(
+	list("STARTING KIT SELECTION:", 0, null, null, null),
+
+	list("INTEGRAL PARTS", 0, null, null, null),
+	list("M34A2-A Multipurpose Turret", 200, /obj/effect/essentials_set/tank/turret, null, VENDOR_ITEM_REGULAR),
+
+	list("PRIMARY WEAPON", 0, null, null, null),
+	list("AC3-E Autocannon", 200, /obj/effect/essentials_set/tank/autocannon, null, VENDOR_ITEM_REGULAR),
+	list("DRG-N Offensive Flamer Unit", 300, /obj/effect/essentials_set/tank/dragonflamer, null, VENDOR_ITEM_REGULAR),
+	list("LTAA-AP Minigun", 300, /obj/effect/essentials_set/tank/gatling, null, VENDOR_ITEM_REGULAR),
+	list("LTB Cannon", 500, /obj/effect/essentials_set/tank/ltb, null, VENDOR_ITEM_RECOMMENDED),
+
+	list("SECONDARY WEAPON", 0, null, null, null),
+	list("M92T Grenade Launcher", 300, /obj/effect/essentials_set/tank/tankgl, null, VENDOR_ITEM_REGULAR),
+	list("M56 Cupola", 200, /obj/effect/essentials_set/tank/m56cupola, null, VENDOR_ITEM_REGULAR),
+	list("LZR-N Flamer Unit", 200, /obj/effect/essentials_set/tank/tankflamer, null, VENDOR_ITEM_REGULAR),
+	list("TOW Launcher", 400, /obj/effect/essentials_set/tank/tow, null, VENDOR_ITEM_RECOMMENDED),
+
+	list("SUPPORT MODULE", 0, null, null, null),
+	list("Artillery Module", 300, /obj/item/hardpoint/support/artillery_module, null, VENDOR_ITEM_REGULAR),
+	list("Integrated Weapons Sensor Array", 300, /obj/item/hardpoint/support/weapons_sensor, null, VENDOR_ITEM_REGULAR),
+	list("Overdrive Enhancer", 300, /obj/item/hardpoint/support/overdrive_enhancer, null, VENDOR_ITEM_RECOMMENDED),
+
+	list("ARMOR", 0, null, null, null),
+	list("External snowplow", 200, /obj/item/hardpoint/armor/snowplow, null, VENDOR_ITEM_REGULAR),
+	list("Ballistic external armor", 200, /obj/item/hardpoint/armor/ballistic, null, VENDOR_ITEM_REGULAR),
+	list("Caustic external armor", 200, /obj/item/hardpoint/armor/caustic, null, VENDOR_ITEM_REGULAR),
+	list("Concussive external armor", 200, /obj/item/hardpoint/armor/concussive, null, VENDOR_ITEM_REGULAR),
+	list("Paladin external armor", 200, /obj/item/hardpoint/armor/paladin, null, VENDOR_ITEM_REGULAR),
+
+	list("TREADS", 0, null, null, null),
+	list("Reinforced Treads", 200, /obj/item/hardpoint/locomotion/treads/robust, null, VENDOR_ITEM_REGULAR),
+	list("Treads", 200, /obj/item/hardpoint/locomotion/treads, null, VENDOR_ITEM_REGULAR)))


### PR DESCRIPTION
# About the pull request
Шаманство с варами у вендора танк-партов, чтобы учитывало очки, иконки частично слетели в самом вендоре со стороны списка при покупке ЗА очки. Включено LTB и TOW
# Explain why it's good for the game
То что существует, должно работать, дальше сами разберетесь.
# Changelog
:cl:
fix: tank tech
/:cl:
