### PR TITLE
Блокировка королевы-крашера

### DIFF
--- a/core_ru/code/includes.dm
+++ b/core_ru/code/includes.dm
@@ -115,6 +115,7 @@
 #include "modules\mob\living\carbon\xenomorph\hive_status.dm"
 #include "modules\mob\living\carbon\xenomorph\xeno_helpers.dm"
 #include "modules\mob\living\carbon\xenomorph\xeno_verbs.dm"
+#include "modules\mob\living\carbon\xenomorph\castes\Queen.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\crusher\crusher_abilities.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\queen\queen_abilities.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\spitter\spitter_abilities.dm"

--- a/core_ru/code/includes.dm
+++ b/core_ru/code/includes.dm
@@ -115,7 +115,6 @@
 #include "modules\mob\living\carbon\xenomorph\hive_status.dm"
 #include "modules\mob\living\carbon\xenomorph\xeno_helpers.dm"
 #include "modules\mob\living\carbon\xenomorph\xeno_verbs.dm"
-#include "modules\mob\living\carbon\xenomorph\castes\Queen.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\crusher\crusher_abilities.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\queen\queen_abilities.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\spitter\spitter_abilities.dm"

--- a/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,5 +1,5 @@
-/*
 /datum/caste_datum/queen
+/*
 	speed = XENO_SPEED_TIER_1
 
 	available_strains = list(/datum/xeno_strain/royal_charger)

--- a/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,4 +1,6 @@
 /datum/caste_datum/queen
+/*
 	speed = XENO_SPEED_TIER_1
 
 	available_strains = list(/datum/xeno_strain/royal_charger)
+*/

--- a/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,4 +1,6 @@
+/*
 /datum/caste_datum/queen
 	speed = XENO_SPEED_TIER_1
 
 	available_strains = list(/datum/xeno_strain/royal_charger)
+*/

--- a/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/core_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,6 +1,4 @@
 /datum/caste_datum/queen
-/*
 	speed = XENO_SPEED_TIER_1
 
 	available_strains = list(/datum/xeno_strain/royal_charger)
-*/


### PR DESCRIPTION
# About the pull request
Мутация / стрейн королевы-крашера более не доступна. Обоснование: затягивание раунда посредством постоянного бегства от превосходящих сил маринов на скорости превышающей скорость призраков. Слишком высокий урон, контроль и не возможность противодействия для малых груп при лоупопе.

Прошлый ПР был дропнут системой отслеживания устаревших ПРов.
# Changelog

:cl:
del: Блокировка королевы-крашера
/:cl:
