### PR TITLE
adds req and id console access

### DIFF
--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -367,7 +367,6 @@
 	var/list/role_needs_id = list(JOB_SO, JOB_CHIEF_ENGINEER, JOB_DROPSHIP_PILOT, JOB_CAS_PILOT, JOB_INTEL)
 //RUCM START
 	var/list/role_needs_cargo = list(JOB_SO, JOB_CHIEF_POLICE, JOB_CMO, JOB_CHIEF_ENGINEER, JOB_DROPSHIP_PILOT, JOB_CAS_PILOT, JOB_INTEL)
-	var/list/role_needs_id_console = list(JOB_DROPSHIP_PILOT, JOB_CAS_PILOT, JOB_INTEL)
 //RUCM END
 	var/list/role_needs_comms = list(JOB_CHIEF_POLICE, JOB_CMO, JOB_CHIEF_ENGINEER, JOB_DROPSHIP_PILOT, JOB_CAS_PILOT, JOB_INTEL)
 	var/announce_addendum
@@ -414,7 +413,7 @@
 			var/list/access = card.access
 			access.Add(ACCESS_MARINE_SENIOR)
 			announce_addendum += "\nSenior Command access added to ID."
-//RUCM START
+//RUCMSTART
 	if(LAZYFIND(role_needs_cargo, role_in_charge))
 //If the role needs cargo access, we need to add it to the ID card
 		var/obj/item/card/id/card = person_in_charge.get_idcard()
@@ -422,14 +421,6 @@
 			var/list/access = card.access
 			access.Add(ACCESS_MARINE_CARGO)
 			announce_addendum += "\nReq access added to ID."
-
-	if(LAZYFIND(role_needs_id_console, role_in_charge))
-   		//If the role needs cargo access, we need to add it to the ID card
-		var/obj/item/card/id/card = person_in_charge.get_idcard()
-		if(card)
-			var/list/access = card.access
-			access.Add(ACCESS_MARINE_DATABASE)
-			announce_addendum += "\nID console access added to ID."
 //RUCM END
 
 	//does an announcement to the crew about the commander & alerts admins to that change for logs.


### PR DESCRIPTION
Добавил доступ при выдаче временного командира для выдачи доступа ID консоли и карго доступ
# About the pull request

Добавляет доступ в карго и в ID консоль для временного командира. При выдаче Senior доступа.

# Explain why it's good for the game

Часто назначают командиров, но они не могут выдать карго и значит никто не может. А так они не просто могут выдать карго, они могут отдать доступ в виде ID console кому то выдать, тот выдаст карго, а они сами могут заняться стратегией короче! Просто круть ведь! Все этого просили, все этого хотели. Вот, сделали, радуемся!


# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog
:cl:
add: access for req and ID console for Temporary Commander whos get Senior access
/:cl:
