### PR TITLE
CO smartgun pick_up fix

### DIFF
--- a/core_ru/code/modules/projectiles/guns/smartgun.dm
+++ b/core_ru/code/modules/projectiles/guns/smartgun.dm
@@ -72,10 +72,10 @@
 // action end \\
 
 /obj/item/weapon/gun/smartgun/m56c/pickup(user)
+	. = ..()
 	if(!linked_human)
 		src.name_after_co(user, src)
 		to_chat(usr, SPAN_NOTICE("[icon2html(src, usr)] You pick up \the [src], registering yourself as its owner."))
-	..()
 
 /obj/item/weapon/gun/smartgun/m56c/proc/name_after_co(mob/living/carbon/human/H, obj/item/weapon/gun/smartgun/m56c/I)
 	linked_human = H


### PR DESCRIPTION
# About the pull request
faf
It just works,the proc legacy system is kinda shifted, as i suppose.
Instead of double parent calling makes just one. Lazy to watch deeper xd






:cl:
fix: CO smartgun pick-up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
