### PR TITLE
SL helmet visor buff

### DIFF
--- a/core_ru/code/modules/clothing/head/helmet.dm
+++ b/core_ru/code/modules/clothing/head/helmet.dm
@@ -12,3 +12,8 @@
 	specialty = "M40 breacher"
 	flags_atom = NO_GAMEMODE_SKIN
 	flags_item = MOB_LOCK_ON_EQUIP|NO_CRYO_STORE
+
+/obj/item/clothing/head/helmet/marine/leader
+	desc = "A variant of the standard M10 pattern helmet. The front plate is reinforced. The second visor slot is present, and the primary one has a basic medical visor installed. This one contains a small built-in camera and has cushioning to project your fragile brain."
+	built_in_visors = list(new /obj/item/device/helmet_visor, new /obj/item/device/helmet_visor/medical)
+	start_down_visor_type = /obj/item/device/helmet_visor/medical


### PR DESCRIPTION
# About the pull request
ПР баффает шлем СЛа - даёт ему встроенный базовый медхуд, оставляя второй слот для визора на выбор. А то получается, что у комтехов встроенный велдинг и есть второй слот, у корпсов встроенный медхуд и есть второй слот, у РТО просто два свободных слота, а у СЛа шлем обычного ПВТ с небольшим баффом брони. Исправляем

# Explain why it's good for the game
Желающие носить ПНВ СЛы не будут требовать М12 в карго.
# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

<img width="988" height="988" alt="image" src="https://github.com/user-attachments/assets/62445609-7cf5-4a7b-9cbb-aaeda3f08282" />

</details>

# Changelog

:cl:
qol: СЛ шлем теперь имеет встроенный базовый медхуд, второй слот всё ещё доступен.
/:cl:
