### PR TITLE
Disable active queen pull

### DIFF
--- a/code_ru/code/colonialmarines_ru.dm
+++ b/code_ru/code/colonialmarines_ru.dm
@@ -40,6 +40,7 @@
 #include "modules\cm_tech\tech_tiers.dm"
 #include "modules\cm_tech\techs\marine\tier2\walker.dm"
 #include "modules\gear_presets\usmc.dm"
+#include "modules\mob\living\carbon\xenomorph\castes\Queen.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\spitter\spitter_abilities.dm"
 #include "modules\mob\living\carbon\xenomorph\abilities\spitter\spitter_powers.dm"
 #include "modules\mob\living\carbon\xenomorph\strains\castes\spitter\suppressor.dm"

--- a/code_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -8,6 +8,8 @@
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
 		puller.apply_effect(rand(caste.tacklestrength_min,caste.tacklestrength_max), WEAKEN)
 		return FALSE
+	if((!ckey) && (!aghosted)) // Should be triggered by xeno or animal species
+		return TRUE
 	if(health > 0) // Should be triggered by xeno or animal species
 		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but was rejected!"))
 		return FALSE

--- a/code_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code_ru/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -1,0 +1,14 @@
+/mob/living/carbon/xenomorph/queen/pull_response(mob/puller)
+	if(stat == DEAD)
+		return TRUE
+	if(legcuffed)
+		return TRUE
+	if(has_species(puller,"Human")) // If the Xeno is alive, fight back against a grab/pull
+		playsound(puller.loc, 'sound/weapons/pierce.ogg', 25, 1)
+		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but instead gets a tail swipe to the head!"))
+		puller.apply_effect(rand(caste.tacklestrength_min,caste.tacklestrength_max), WEAKEN)
+		return FALSE
+	if(health > 0) // Should be triggered by xeno or animal species
+		puller.visible_message(SPAN_WARNING("[puller] tried to pull [src] but was rejected!"))
+		return FALSE
+	return TRUE


### PR DESCRIPTION

# About the pull request

Disable queen pull when it's alive and not in critical to prevent runner-pull abuse and sound-off stomp movement.

# Explain why it's good for the game

Experiment on fixing one specific issues, there other way to fix it, ensuring the queen makes sounds in range and bigger pull-speed reduce but it's not necessary

# Changelog

:cl:
balance: disabled active queen pull
/:cl:
